### PR TITLE
Disable Codecov GitHub checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false


### PR DESCRIPTION
For now test coverage is only informative and the GitHub checks shown in the review are annoying. For the time being, we can include this change to disable those checks globally from the "Files changed" view. Once we actually start caring for code coverage, we can revert this.

Documentation: https://docs.codecov.com/docs/github-checks