### PR TITLE
refactor: stop using sqlx::any

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +617,18 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dummy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57e12b69e57fad516e01e2b3960f122696fdb13420e1a88ed8e210316f2876"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -701,6 +719,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+dependencies = [
+ "deunicode",
+ "dummy",
+ "rand",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,10 +745,12 @@ dependencies = [
  "bytes",
  "derive_builder",
  "derive_more",
+ "fake",
  "flareon_macros",
  "form_urlencoded",
  "indexmap",
  "log",
+ "rand",
  "regex",
  "sea-query",
  "sea-query-binder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ darling = "0.20.10"
 derive_builder = "0.20.0"
 derive_more = { version = "1.0.0", features = ["full"] }
 env_logger = "0.11.3"
+fake = { version = "2.9.2", features = ["derive"] }
 flareon = { path = "flareon" }
 flareon_codegen = { path = "flareon-codegen" }
 flareon_macros = { path = "flareon-macros" }
@@ -43,12 +44,13 @@ prettyplease = "0.2.20"
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
+rand = "0.8.5"
 regex = "1.10.5"
 sea-query = "0.32.0-rc.1"
-sea-query-binder = { version = "0.7.0-rc.1", features = ["sqlx-any", "runtime-tokio"] }
+sea-query-binder = { version = "0.7.0-rc.1", features = ["sqlx-sqlite", "runtime-tokio"] }
 serde = "1.0.203"
 slug = "0.1.5"
-sqlx = { version = "0.8.0", default-features = false, features = ["any", "macros", "json", "runtime-tokio", "sqlite"] }
+sqlx = { version = "0.8.0", default-features = false, features = ["macros", "json", "runtime-tokio", "sqlite"] }
 syn = { version = "2.0.74", features = ["full", "extra-traits"] }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -73,7 +73,7 @@ async fn remove_todo(request: Request) -> Result<Response, Error> {
     {
         let db = DB.get().unwrap();
         TodoItem::objects()
-            .filter(<TodoItem as Model>::Fields::ID.eq(todo_id))
+            .filter(<TodoItem as Model>::Fields::id.eq(todo_id))
             .delete(db)
             .await?;
     }

--- a/flareon-codegen/src/model.rs
+++ b/flareon-codegen/src/model.rs
@@ -61,7 +61,7 @@ impl FieldOpts {
     #[must_use]
     pub fn as_field(&self) -> Field {
         let name = self.ident.as_ref().unwrap();
-        let column_name = name.to_string().to_case(Case::Snake);
+        let column_name = name.to_string();
         let is_auto = column_name == "id";
 
         Field {

--- a/flareon/Cargo.toml
+++ b/flareon/Cargo.toml
@@ -22,3 +22,7 @@ sea-query.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+fake.workspace = true
+rand.workspace = true

--- a/flareon/src/db/db_sqlite.rs
+++ b/flareon/src/db/db_sqlite.rs
@@ -1,0 +1,134 @@
+use derive_more::Debug;
+use flareon::db::{SqlxRowRef, SqlxValueRef};
+use log::debug;
+use sea_query::{QueryStatementWriter, SchemaStatementBuilder, SqliteQueryBuilder};
+use sea_query_binder::{SqlxBinder, SqlxValues};
+use sqlx::{Database, Row, SqlitePool};
+
+use super::{Result, RowsNum, StatementResult};
+
+#[derive(Debug)]
+pub(super) struct DatabaseSqlite {
+    db_connection: SqlitePool,
+}
+
+impl DatabaseSqlite {
+    pub(super) async fn new(url: &str) -> Result<Self> {
+        let db_connection = SqlitePool::connect(url).await?;
+
+        Ok(Self { db_connection })
+    }
+
+    pub(super) async fn close(self) -> Result<()> {
+        self.db_connection.close().await;
+        Ok(())
+    }
+
+    pub(super) async fn fetch_one<T: SqlxBinder>(&self, statement: T) -> Result<SqliteRow> {
+        let (sql, values) = Self::build_sql(statement);
+
+        let row = sqlx::query_with(&sql, values)
+            .fetch_one(&self.db_connection)
+            .await?;
+        Ok(SqliteRow::new(row))
+    }
+
+    pub(super) async fn fetch_all<T: SqlxBinder>(&self, statement: T) -> Result<Vec<SqliteRow>> {
+        let (sql, values) = Self::build_sql(statement);
+
+        let result = sqlx::query_with(&sql, values)
+            .fetch_all(&self.db_connection)
+            .await?
+            .into_iter()
+            .map(SqliteRow::new)
+            .collect();
+        Ok(result)
+    }
+
+    pub(super) async fn execute_statement<T: SqlxBinder>(
+        &self,
+        statement: T,
+    ) -> Result<StatementResult> {
+        let (sql, values) = Self::build_sql(statement);
+
+        self.execute_sqlx(sqlx::query_with(&sql, values)).await
+    }
+
+    pub(super) async fn execute_schema<T: SchemaStatementBuilder>(
+        &self,
+        statement: T,
+    ) -> Result<StatementResult> {
+        let sql = statement.build(SqliteQueryBuilder);
+        debug!("Schema modification: {}", sql);
+
+        self.execute_sqlx(sqlx::query(&sql)).await
+    }
+
+    async fn execute_sqlx<'a, A>(
+        &self,
+        sqlx_statement: sqlx::query::Query<'a, sqlx::sqlite::Sqlite, A>,
+    ) -> Result<StatementResult>
+    where
+        A: 'a + sqlx::IntoArguments<'a, sqlx::sqlite::Sqlite>,
+    {
+        let result = sqlx_statement.execute(&self.db_connection).await?;
+        let result = StatementResult {
+            rows_affected: RowsNum(result.rows_affected()),
+        };
+
+        debug!("Rows affected: {}", result.rows_affected.0);
+        Ok(result)
+    }
+
+    fn build_sql<T>(statement: T) -> (String, SqlxValues)
+    where
+        T: SqlxBinder,
+    {
+        let (sql, values) = statement.build_sqlx(SqliteQueryBuilder);
+        debug!("SQLite Query: {}", sql);
+
+        (sql, values)
+    }
+}
+
+#[derive(Debug)]
+pub struct SqliteRow {
+    #[debug("...")]
+    inner: sqlx::sqlite::SqliteRow,
+}
+
+impl SqliteRow {
+    #[must_use]
+    fn new(inner: sqlx::sqlite::SqliteRow) -> Self {
+        Self { inner }
+    }
+}
+
+impl SqlxRowRef for SqliteRow {
+    type ValueRef<'r> = SqliteValueRef<'r>;
+
+    fn get_raw(&self, index: usize) -> Result<Self::ValueRef<'_>> {
+        Ok(SqliteValueRef::new(self.inner.try_get_raw(index)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct SqliteValueRef<'r> {
+    #[debug("...")]
+    inner: sqlx::sqlite::SqliteValueRef<'r>,
+}
+
+impl<'r> SqliteValueRef<'r> {
+    #[must_use]
+    fn new(inner: sqlx::sqlite::SqliteValueRef<'r>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'r> SqlxValueRef<'r> for SqliteValueRef<'r> {
+    type DB = sqlx::Sqlite;
+
+    fn get_raw(self) -> <Self::DB as Database>::ValueRef<'r> {
+        self.inner
+    }
+}

--- a/flareon/src/db/fields.rs
+++ b/flareon/src/db/fields.rs
@@ -1,7 +1,7 @@
 use flareon::db::DbField;
 use sea_query::Value;
 
-use crate::db::{ColumnType, FromDbValue, Result, SqlxValueRef, ToDbValue};
+use crate::db::{ColumnType, FromDbValue, Result, SqliteValueRef, SqlxValueRef, ToDbValue};
 
 macro_rules! impl_db_field {
     ($ty:ty, $column_type:ident) => {
@@ -10,7 +10,7 @@ macro_rules! impl_db_field {
         }
 
         impl FromDbValue for $ty {
-            fn from_sqlx(value: SqlxValueRef) -> Result<Self> {
+            fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
                 value.get::<$ty>()
             }
         }

--- a/flareon/src/db/query.rs
+++ b/flareon/src/db/query.rs
@@ -4,7 +4,7 @@ use derive_more::Debug;
 use sea_query::IntoColumnRef;
 
 use crate::db;
-use crate::db::{Database, FromDbValue, Identifier, Model, QueryResult, ToDbValue};
+use crate::db::{Database, FromDbValue, Identifier, Model, StatementResult, ToDbValue};
 
 #[derive(Debug)]
 pub struct Query<T> {
@@ -36,7 +36,7 @@ impl<T: Model> Query<T> {
         db.query(self).await
     }
 
-    pub async fn delete(&self, db: &Database) -> db::Result<QueryResult> {
+    pub async fn delete(&self, db: &Database) -> db::Result<StatementResult> {
         db.delete(self).await
     }
 

--- a/flareon/tests/db.rs
+++ b/flareon/tests/db.rs
@@ -1,0 +1,122 @@
+use fake::{Dummy, Fake, Faker};
+use flareon::db::migrations::{Field, Operation};
+use flareon::db::query::ExprEq;
+use flareon::db::{model, Database, DbField, Identifier, Model};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+#[tokio::test]
+async fn test_model_crud() {
+    let db = test_sqlite_db().await;
+
+    migrate_test_model(&db).await;
+
+    assert_eq!(TestModel::objects().all(&db).await.unwrap(), vec![]);
+
+    let mut model = TestModel {
+        id: 0,
+        name: "test".to_owned(),
+    };
+    model.save(&db).await.unwrap();
+    let objects = TestModel::objects().all(&db).await.unwrap();
+    assert_eq!(objects.len(), 1);
+    assert_eq!(objects[0].name, "test");
+
+    TestModel::objects()
+        .filter(<TestModel as Model>::Fields::id.eq(1))
+        .delete(&db)
+        .await
+        .unwrap();
+
+    assert_eq!(TestModel::objects().all(&db).await.unwrap(), vec![]);
+
+    db.close().await.unwrap();
+}
+
+#[derive(Debug, PartialEq)]
+#[model]
+struct TestModel {
+    id: i32,
+    name: String,
+}
+
+async fn migrate_test_model(db: &Database) {
+    crate::CREATE_TEST_MODEL.forwards(db).await.unwrap();
+}
+
+const CREATE_TEST_MODEL: Operation = Operation::CreateModel {
+    table_name: Identifier::new("test_model"),
+    fields: &[
+        Field::new(Identifier::new("id"), <i32 as DbField>::TYPE)
+            .primary_key()
+            .auto(),
+        Field::new(Identifier::new("name"), <String as DbField>::TYPE),
+    ],
+};
+
+macro_rules! all_fields_migration_field {
+    ($name:ident, $ty:ty) => {
+        Field::new(
+            Identifier::new(concat!("field_", stringify!($name))),
+            <$ty as DbField>::TYPE,
+        )
+    };
+    ($ty:ty) => {
+        Field::new(
+            Identifier::new(concat!("field_", stringify!($ty))),
+            <$ty as DbField>::TYPE,
+        )
+    };
+}
+
+#[derive(Debug, PartialEq, Dummy)]
+#[model]
+struct AllFieldsModel {
+    #[dummy(expr = "0i32")]
+    id: i32,
+    field_i16: i16,
+    field_i32: i32,
+    field_i64: i64,
+    field_string: String,
+}
+
+async fn migrate_all_fields_model(db: &Database) {
+    CREATE_ALL_FIELDS_MODEL.forwards(db).await.unwrap();
+}
+
+const CREATE_ALL_FIELDS_MODEL: Operation = Operation::CreateModel {
+    table_name: Identifier::new("all_fields_model"),
+    fields: &[
+        Field::new(Identifier::new("id"), <i32 as DbField>::TYPE)
+            .primary_key()
+            .auto(),
+        all_fields_migration_field!(i16),
+        all_fields_migration_field!(i32),
+        all_fields_migration_field!(i64),
+        all_fields_migration_field!(string, String),
+    ],
+};
+
+#[tokio::test]
+async fn test_all_fields_model() {
+    let db = test_sqlite_db().await;
+
+    migrate_all_fields_model(&db).await;
+
+    assert_eq!(AllFieldsModel::objects().all(&db).await.unwrap(), vec![]);
+
+    let r = &mut StdRng::seed_from_u64(123_785);
+    for _ in 0..100 {
+        let mut model: AllFieldsModel = Faker.fake_with_rng(r);
+        model.save(&db).await.unwrap();
+    }
+
+    let objects = AllFieldsModel::objects().all(&db).await.unwrap();
+    assert_eq!(objects.len(), 100);
+
+    db.close().await.unwrap();
+}
+
+async fn test_sqlite_db() -> Database {
+    Database::new("sqlite::memory:").await.unwrap()
+}


### PR DESCRIPTION
This limits our choices for supported data types stored in the DB (e.g. no support for i8/u8). It's easiest to make the switch now, so now we differentiate between DB backends.