### PR TITLE
chore: hide some enums' internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +763,7 @@ name = "flareon"
 version = "0.1.0"
 dependencies = [
  "askama",
+ "async-stream",
  "async-trait",
  "axum",
  "bytes",
@@ -750,6 +773,7 @@ dependencies = [
  "fake",
  "flareon_macros",
  "form_urlencoded",
+ "futures",
  "futures-core",
  "http-body",
  "indexmap",
@@ -845,6 +869,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,8 +956,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.86"
 askama = "0.12.1"
+async-stream = "0.3.5"
 async-trait = "0.1.80"
 axum = "0.7.5"
 bytes = "1.7.1"
@@ -36,6 +37,7 @@ flareon = { path = "flareon" }
 flareon_codegen = { path = "flareon-codegen" }
 flareon_macros = { path = "flareon-macros" }
 form_urlencoded = "1.2.1"
+futures = "0.3.30"
 futures-core = "0.3.30"
 glob = "0.3.1"
 http-body = "1.0.1"

--- a/examples/todo-list/src/migrations/m_0001_initial.rs
+++ b/examples/todo-list/src/migrations/m_0001_initial.rs
@@ -10,13 +10,13 @@ impl ::flareon::db::migrations::Migration for Migration {
             .fields(&[
                 ::flareon::db::migrations::Field::new(
                     ::flareon::db::Identifier::new("id"),
-                    <i32 as ::flareon::db::DatbaseField>::TYPE,
+                    <i32 as ::flareon::db::DatabaseField>::TYPE,
                 )
                 .auto()
                 .primary_key(),
                 ::flareon::db::migrations::Field::new(
                     ::flareon::db::Identifier::new("title"),
-                    <String as ::flareon::db::DatbaseField>::TYPE,
+                    <String as ::flareon::db::DatabaseField>::TYPE,
                 ),
             ])
             .build()];

--- a/flareon-cli/src/migration_generator.rs
+++ b/flareon-cli/src/migration_generator.rs
@@ -507,7 +507,7 @@ impl Repr for Field {
         let column_name = &self.column_name;
         let ty = &self.ty;
         let mut tokens = quote! {
-            ::flareon::db::migrations::Field::new(::flareon::db::Identifier::new(#column_name), <#ty as ::flareon::db::DbField>::TYPE)
+            ::flareon::db::migrations::Field::new(::flareon::db::Identifier::new(#column_name), <#ty as ::flareon::db::DatabaseField>::TYPE)
         };
         if self.auto_value {
             tokens = quote! { #tokens.auto() }

--- a/flareon/Cargo.toml
+++ b/flareon/Cargo.toml
@@ -27,5 +27,7 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+async-stream.workspace = true
 fake.workspace = true
+futures.workspace = true
 rand.workspace = true

--- a/flareon/src/db.rs
+++ b/flareon/src/db.rs
@@ -202,7 +202,7 @@ impl Row {
     }
 }
 
-pub trait DatbaseField: FromDbValue + ToDbValue {
+pub trait DatabaseField: FromDbValue + ToDbValue {
     const TYPE: ColumnType;
 }
 

--- a/flareon/src/db/fields.rs
+++ b/flareon/src/db/fields.rs
@@ -1,11 +1,11 @@
-use flareon::db::DatbaseField;
+use flareon::db::DatabaseField;
 use sea_query::Value;
 
 use crate::db::{ColumnType, FromDbValue, Result, SqliteValueRef, SqlxValueRef, ToDbValue};
 
 macro_rules! impl_db_field {
     ($ty:ty, $column_type:ident) => {
-        impl DatbaseField for $ty {
+        impl DatabaseField for $ty {
             const TYPE: ColumnType = ColumnType::$column_type;
         }
 

--- a/flareon/src/lib.rs
+++ b/flareon/src/lib.rs
@@ -136,34 +136,90 @@ impl Response {
     }
 }
 
-pub enum Body {
+/// A type that represents an HTTP response body.
+///
+/// This type is used to represent the body of an HTTP response. It can be
+/// either a fixed body (e.g., a string or a byte array) or a streaming body
+/// (e.g., a large file or a database query result).
+///
+/// # Examples
+///
+/// ```
+/// use flareon::Body;
+///
+/// let body = Body::fixed("Hello, world!");
+/// let body = Body::streaming(futures::stream::once(async { Ok("Hello, world!".into()) }));
+/// ```
+#[derive(Debug)]
+pub struct Body {
+    inner: BodyInner,
+}
+
+enum BodyInner {
     Fixed(Bytes),
     Streaming(Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>),
 }
 
-impl Debug for Body {
+impl Debug for BodyInner {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Body::Fixed(data) => f.debug_tuple("Fixed").field(data).finish(),
-            Body::Streaming(_) => f.debug_tuple("Streaming").field(&"...").finish(),
+            Self::Fixed(data) => f.debug_tuple("Fixed").field(data).finish(),
+            Self::Streaming(_) => f.debug_tuple("Streaming").field(&"...").finish(),
         }
     }
 }
 
 impl Body {
     #[must_use]
-    pub fn empty() -> Self {
-        Self::Fixed(Bytes::new())
+    const fn new(inner: BodyInner) -> Self {
+        Self { inner }
     }
 
+    /// Create an empty body.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flareon::Body;
+    ///
+    /// let body = Body::empty();
+    /// ```
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self::new(BodyInner::Fixed(Bytes::new()))
+    }
+
+    /// Create a body instance with the given fixed data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use flareon::Body;
+    ///
+    /// let body = Body::fixed("Hello, world!");
+    /// ```
     #[must_use]
     pub fn fixed<T: Into<Bytes>>(data: T) -> Self {
-        Self::Fixed(data.into())
+        Self::new(BodyInner::Fixed(data.into()))
     }
 
+    /// Create a body instance from a stream of data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_stream::stream;
+    /// use flareon::Body;
+    ///
+    /// let stream = stream! {
+    ///    yield Ok("Hello, ".into());
+    ///    yield Ok("world!".into());
+    /// };
+    /// let body = Body::streaming(stream);
+    /// ```
     #[must_use]
     pub fn streaming<T: Stream<Item = Result<Bytes>> + Send + 'static>(stream: T) -> Self {
-        Self::Streaming(Box::pin(stream))
+        Self::new(BodyInner::Streaming(Box::pin(stream)))
     }
 }
 
@@ -175,8 +231,8 @@ impl http_body::Body for Body {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<std::result::Result<Frame<Self::Data>, Self::Error>>> {
-        match self.get_mut() {
-            Body::Fixed(ref mut data) => {
+        match self.get_mut().inner {
+            BodyInner::Fixed(ref mut data) => {
                 if data.is_empty() {
                     Poll::Ready(None)
                 } else {
@@ -184,7 +240,7 @@ impl http_body::Body for Body {
                     Poll::Ready(Some(Ok(Frame::data(data))))
                 }
             }
-            Body::Streaming(ref mut stream) => {
+            BodyInner::Streaming(ref mut stream) => {
                 let stream = Pin::as_mut(stream);
                 match stream.poll_next(cx) {
                     Poll::Ready(Some(result)) => Poll::Ready(Some(result.map(Frame::data))),
@@ -196,16 +252,16 @@ impl http_body::Body for Body {
     }
 
     fn is_end_stream(&self) -> bool {
-        match self {
-            Body::Fixed(data) => data.is_empty(),
-            Body::Streaming(_) => false,
+        match &self.inner {
+            BodyInner::Fixed(data) => data.is_empty(),
+            BodyInner::Streaming(_) => false,
         }
     }
 
     fn size_hint(&self) -> SizeHint {
-        match self {
-            Body::Fixed(data) => SizeHint::with_exact(data.len() as u64),
-            Body::Streaming(_) => SizeHint::new(),
+        match &self.inner {
+            BodyInner::Fixed(data) => SizeHint::with_exact(data.len() as u64),
+            BodyInner::Streaming(_) => SizeHint::new(),
         }
     }
 }
@@ -368,6 +424,12 @@ fn handle_response_error(_error: Error) -> axum::response::Response {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use futures::stream;
+    use http_body::Body as HttpBody;
+
     use super::*;
 
     #[test]
@@ -412,5 +474,94 @@ mod tests {
         builder.register_app_with_views(app, "/app");
         let project = builder.build();
         assert_eq!(project.router().routes().len(), 1);
+    }
+
+    #[test]
+    fn test_body_empty() {
+        let body = Body::empty();
+        if let BodyInner::Fixed(data) = body.inner {
+            assert!(data.is_empty());
+        } else {
+            panic!("Body::empty should create a fixed empty body");
+        }
+    }
+
+    #[test]
+    fn test_body_fixed() {
+        let content = "Hello, world!";
+        let body = Body::fixed(content);
+        if let BodyInner::Fixed(data) = body.inner {
+            assert_eq!(data, Bytes::from(content));
+        } else {
+            panic!("Body::fixed should create a fixed body with the given content");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_body_streaming() {
+        let stream = stream::once(async { Ok(Bytes::from("Hello, world!")) });
+        let body = Body::streaming(stream);
+        if let BodyInner::Streaming(_) = body.inner {
+            // Streaming body created successfully
+        } else {
+            panic!("Body::streaming should create a streaming body");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_body_poll_frame_fixed() {
+        let content = "Hello, world!";
+        let mut body = Body::fixed(content);
+        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+
+        match Pin::new(&mut body).poll_frame(&mut cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                assert_eq!(frame.into_data().unwrap(), Bytes::from(content));
+            }
+            _ => panic!("Body::fixed should return the content in poll_frame"),
+        }
+
+        match Pin::new(&mut body).poll_frame(&mut cx) {
+            Poll::Ready(None) => {} // End of stream
+            _ => panic!("Body::fixed should return None after the content is consumed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_body_poll_frame_streaming() {
+        let content = "Hello, world!";
+        let mut body = Body::streaming(stream::once(async move { Ok(Bytes::from(content)) }));
+        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+
+        match Pin::new(&mut body).poll_frame(&mut cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                assert_eq!(frame.into_data().unwrap(), Bytes::from(content));
+            }
+            _ => panic!("Body::fixed should return the content in poll_frame"),
+        }
+
+        match Pin::new(&mut body).poll_frame(&mut cx) {
+            Poll::Ready(None) => {} // End of stream
+            _ => panic!("Body::fixed should return None after the content is consumed"),
+        }
+    }
+
+    #[test]
+    fn test_http_body_is_end_stream() {
+        let body = Body::empty();
+        assert!(body.is_end_stream());
+
+        let body = Body::fixed("Hello, world!");
+        assert!(!body.is_end_stream());
+    }
+
+    #[test]
+    fn test_http_body_size_hint() {
+        let body = Body::empty();
+        assert_eq!(body.size_hint().exact(), Some(0));
+
+        let content = "Hello, world!";
+        let body = Body::fixed(content);
+        assert_eq!(body.size_hint().exact(), Some(content.len() as u64));
     }
 }

--- a/flareon/src/router.rs
+++ b/flareon/src/router.rs
@@ -172,7 +172,7 @@ impl Route {
 fn handle_not_found() -> Response {
     Response::new_html(
         StatusCode::NOT_FOUND,
-        Body::Fixed(Bytes::from("404 Not Found")),
+        Body::fixed(Bytes::from("404 Not Found")),
     )
 }
 
@@ -235,7 +235,7 @@ mod tests {
         async fn handle(&self, _request: Request) -> Result<Response> {
             Ok(Response::new_html(
                 StatusCode::OK,
-                Body::Fixed(Bytes::from("OK")),
+                Body::fixed(Bytes::from("OK")),
             ))
         }
     }

--- a/flareon/tests/db.rs
+++ b/flareon/tests/db.rs
@@ -1,7 +1,7 @@
 use fake::{Dummy, Fake, Faker};
 use flareon::db::migrations::{Field, Operation};
 use flareon::db::query::ExprEq;
-use flareon::db::{model, query, Database, DatbaseField, Identifier, Model};
+use flareon::db::{model, query, Database, DatabaseField, Identifier, Model};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
@@ -70,10 +70,10 @@ async fn migrate_test_model(db: &Database) {
 const CREATE_TEST_MODEL: Operation = Operation::create_model()
     .table_name(Identifier::new("test_model"))
     .fields(&[
-        Field::new(Identifier::new("id"), <i32 as DatbaseField>::TYPE)
+        Field::new(Identifier::new("id"), <i32 as DatabaseField>::TYPE)
             .primary_key()
             .auto(),
-        Field::new(Identifier::new("name"), <String as DatbaseField>::TYPE),
+        Field::new(Identifier::new("name"), <String as DatabaseField>::TYPE),
     ])
     .build();
 
@@ -81,13 +81,13 @@ macro_rules! all_fields_migration_field {
     ($name:ident, $ty:ty) => {
         Field::new(
             Identifier::new(concat!("field_", stringify!($name))),
-            <$ty as DatbaseField>::TYPE,
+            <$ty as DatabaseField>::TYPE,
         )
     };
     ($ty:ty) => {
         Field::new(
             Identifier::new(concat!("field_", stringify!($ty))),
-            <$ty as DatbaseField>::TYPE,
+            <$ty as DatabaseField>::TYPE,
         )
     };
 }
@@ -125,7 +125,7 @@ async fn migrate_all_fields_model(db: &Database) {
 const CREATE_ALL_FIELDS_MODEL: Operation = Operation::create_model()
     .table_name(Identifier::new("all_fields_model"))
     .fields(&[
-        Field::new(Identifier::new("id"), <i32 as DatbaseField>::TYPE)
+        Field::new(Identifier::new("id"), <i32 as DatabaseField>::TYPE)
             .primary_key()
             .auto(),
         all_fields_migration_field!(bool),


### PR DESCRIPTION
`Body` and `Operation` are not supposed to be constructed directly by the user, so they were hidden behind a private field in a struct.

This also adds some new tests and docs.