### PR TITLE
refactor: hide Error details behind a private ErrorRepr enum

### DIFF
--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,9 +1,9 @@
 use flareon::request::Request;
 use flareon::response::{Response, ResponseExt};
 use flareon::router::Route;
-use flareon::{Body, Error, FlareonApp, FlareonProject, StatusCode};
+use flareon::{Body, FlareonApp, FlareonProject, StatusCode};
 
-async fn return_hello(_request: Request) -> Result<Response, Error> {
+async fn return_hello(_request: Request) -> flareon::Result<Response> {
     Ok(Response::new_html(
         StatusCode::OK,
         Body::fixed("<h1>Hello Flareon!</h1>".as_bytes().to_vec()),

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -4,7 +4,7 @@ use flareon::middleware::SessionMiddleware;
 use flareon::request::{Request, RequestExt};
 use flareon::response::{Response, ResponseExt};
 use flareon::router::Route;
-use flareon::{reverse, Body, Error, FlareonApp, FlareonProject, StatusCode};
+use flareon::{reverse, Body, FlareonApp, FlareonProject, StatusCode};
 
 #[derive(Debug, Template)]
 #[template(path = "index.html")]
@@ -25,7 +25,7 @@ struct NameForm {
     name: String,
 }
 
-async fn hello(request: Request) -> Result<Response, Error> {
+async fn hello(request: Request) -> flareon::Result<Response> {
     let name: String = request
         .session()
         .get("user_name")
@@ -47,7 +47,7 @@ async fn hello(request: Request) -> Result<Response, Error> {
     ))
 }
 
-async fn name(mut request: Request) -> Result<Response, Error> {
+async fn name(mut request: Request) -> flareon::Result<Response> {
     if request.method() == flareon::Method::POST {
         let name_form = NameForm::from_request(&mut request).await.unwrap();
         request

--- a/examples/todo-list/src/main.rs
+++ b/examples/todo-list/src/main.rs
@@ -7,7 +7,7 @@ use flareon::forms::Form;
 use flareon::request::{Request, RequestExt};
 use flareon::response::{Response, ResponseExt};
 use flareon::router::Route;
-use flareon::{reverse, Body, Error, FlareonApp, FlareonProject, StatusCode};
+use flareon::{reverse, Body, FlareonApp, FlareonProject, StatusCode};
 use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone)]
@@ -26,7 +26,7 @@ struct IndexTemplate<'a> {
 
 static DB: OnceCell<Database> = OnceCell::const_new();
 
-async fn index(request: Request) -> Result<Response, Error> {
+async fn index(request: Request) -> flareon::Result<Response> {
     let db = DB.get().unwrap();
 
     let todo_items = TodoItem::objects().all(db).await?;
@@ -45,7 +45,7 @@ struct TodoForm {
     title: String,
 }
 
-async fn add_todo(mut request: Request) -> Result<Response, Error> {
+async fn add_todo(mut request: Request) -> flareon::Result<Response> {
     let todo_form = TodoForm::from_request(&mut request).await.unwrap();
 
     {
@@ -61,7 +61,7 @@ async fn add_todo(mut request: Request) -> Result<Response, Error> {
     Ok(reverse!(request, "index"))
 }
 
-async fn remove_todo(request: Request) -> Result<Response, Error> {
+async fn remove_todo(request: Request) -> flareon::Result<Response> {
     let todo_id = request
         .path_params()
         .get("todo_id")

--- a/flareon/tests/router.rs
+++ b/flareon/tests/router.rs
@@ -3,16 +3,16 @@ use flareon::request::{Request, RequestExt};
 use flareon::response::{Response, ResponseExt};
 use flareon::router::{Route, RouterService};
 use flareon::test::Client;
-use flareon::{Body, Error, FlareonApp, FlareonProject, StatusCode};
+use flareon::{Body, FlareonApp, FlareonProject, StatusCode};
 
-async fn index(_request: Request) -> Result<Response, Error> {
+async fn index(_request: Request) -> flareon::Result<Response> {
     Ok(Response::new_html(
         StatusCode::OK,
         Body::fixed("Hello world!"),
     ))
 }
 
-async fn parameterized(request: Request) -> Result<Response, Error> {
+async fn parameterized(request: Request) -> flareon::Result<Response> {
     let name = request.path_params().get("name").unwrap().to_owned();
 
     Ok(Response::new_html(StatusCode::OK, Body::fixed(name)))


### PR DESCRIPTION
The user should never have to check the exact type of error, and this will provide us with a much easier semver-compatibility.

The main reason for the change though is to store additional generic data in the Error struct (namely a backtrace - will come in the next change).