### PR TITLE
feat(db): add support for Vec<u8>; small refactor

### DIFF
--- a/flareon/src/auth.rs
+++ b/flareon/src/auth.rs
@@ -405,7 +405,7 @@ impl FromDbValue for PasswordHash {
 }
 
 impl ToDbValue for PasswordHash {
-    fn as_sea_query_value(&self) -> sea_query::Value {
+    fn to_sea_query_value(&self) -> sea_query::Value {
         self.0.clone().into()
     }
 }

--- a/flareon/src/db/fields.rs
+++ b/flareon/src/db/fields.rs
@@ -16,7 +16,7 @@ macro_rules! impl_db_field {
         }
 
         impl ToDbValue for $ty {
-            fn as_sea_query_value(&self) -> Value {
+            fn to_sea_query_value(&self) -> Value {
                 self.clone().into()
             }
         }
@@ -39,9 +39,10 @@ impl_db_field!(chrono::NaiveTime, Time);
 impl_db_field!(chrono::NaiveDateTime, DateTime);
 impl_db_field!(chrono::DateTime<chrono::FixedOffset>, TimestampWithTimeZone);
 impl_db_field!(String, Text);
+impl_db_field!(Vec<u8>, Blob);
 
 impl ToDbValue for &str {
-    fn as_sea_query_value(&self) -> Value {
+    fn to_sea_query_value(&self) -> Value {
         (*self).to_string().into()
     }
 }

--- a/flareon/src/db/migrations.rs
+++ b/flareon/src/db/migrations.rs
@@ -584,6 +584,7 @@ impl From<ColumnType> for sea_query::ColumnType {
             ColumnType::Timestamp => Self::Timestamp,
             ColumnType::TimestampWithTimeZone => Self::TimestampWithTimeZone,
             ColumnType::Text => Self::Text,
+            ColumnType::Blob => Self::Blob,
         }
     }
 }

--- a/flareon/src/db/query.rs
+++ b/flareon/src/db/query.rs
@@ -131,7 +131,7 @@ impl<T: Model> Query<T> {
 #[derive(Debug)]
 pub enum Expr {
     Field(Identifier),
-    Value(#[debug("{}", _0.as_sea_query_value())] Box<dyn ToDbValue>),
+    Value(#[debug("{}", _0.to_sea_query_value())] Box<dyn ToDbValue>),
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
     Eq(Box<Expr>, Box<Expr>),
@@ -299,7 +299,7 @@ impl Expr {
     pub fn as_sea_query_expr(&self) -> sea_query::SimpleExpr {
         match self {
             Self::Field(identifier) => (*identifier).into_column_ref().into(),
-            Self::Value(value) => value.as_sea_query_value().into(),
+            Self::Value(value) => value.to_sea_query_value().into(),
             Self::And(lhs, rhs) => lhs.as_sea_query_expr().and(rhs.as_sea_query_expr()),
             Self::Or(lhs, rhs) => lhs.as_sea_query_expr().or(rhs.as_sea_query_expr()),
             Self::Eq(lhs, rhs) => lhs.as_sea_query_expr().eq(rhs.as_sea_query_expr()),
@@ -505,7 +505,7 @@ mod tests {
     fn test_expr_value() {
         let expr = Expr::value(30);
         if let Expr::Value(value) = expr {
-            assert_eq!(value.as_sea_query_value().to_string(), "30");
+            assert_eq!(value.to_sea_query_value().to_string(), "30");
         } else {
             panic!("Expected Expr::Value");
         }

--- a/flareon/tests/db.rs
+++ b/flareon/tests/db.rs
@@ -116,6 +116,7 @@ struct AllFieldsModel {
     field_datetime: chrono::NaiveDateTime,
     field_datetime_timezone: chrono::DateTime<chrono::FixedOffset>,
     field_string: String,
+    field_blob: Vec<u8>,
 }
 
 async fn migrate_all_fields_model(db: &Database) {
@@ -144,6 +145,7 @@ const CREATE_ALL_FIELDS_MODEL: Operation = Operation::create_model()
         all_fields_migration_field!(datetime, chrono::NaiveDateTime),
         all_fields_migration_field!(datetime_timezone, chrono::DateTime<chrono::FixedOffset>),
         all_fields_migration_field!(string, String),
+        all_fields_migration_field!(blob, Vec<u8>),
     ])
     .build();
 


### PR DESCRIPTION
This changes the name of as_sea_query_value() to to_sea_query_value() to better conform with Rust's typical method naming.