### PR TITLE
feat(orm): postgres support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,42 @@ jobs:
       - name: Run clippy
         run: cargo clippy --no-deps -- -Dclippy::all -Wclippy::pedantic
 
+  external-deps:
+    if: github.event_name == 'push' || github.event_name == 'schedule' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    name: Test with external dependencies
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Build
+        run: cargo build
+
+      - name: Run the external dependencies
+        run: docker compose up -d
+
+      - name: Test
+        run: cargo nextest run --all-features -- --include-ignored
+
+      - name: Test docs
+        run: cargo test --doc
+
   coverage:
     if: github.event_name == 'push' || github.event_name == 'schedule' ||
       github.event.pull_request.head.repo.full_name != github.repository
@@ -101,8 +137,11 @@ jobs:
       - name: Cache Cargo registry
         uses: Swatinem/rust-cache@v2
 
+      - name: Run the external dependencies
+        run: docker compose up -d
+
       - name: Test
-        run: cargo test --all-features --no-fail-fast
+        run: cargo test --all-features --no-fail-fast -- --include-ignored
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,11 @@ rand = "0.8"
 regex = "1.11"
 rustversion = "1"
 sea-query = "0.32.0-rc.2"
-sea-query-binder = { version = "0.7.0-rc.2", features = ["sqlx-sqlite", "with-chrono", "runtime-tokio"] }
+sea-query-binder = { version = "0.7.0-rc.2", features = ["sqlx-sqlite", "sqlx-postgres", "with-chrono", "runtime-tokio"] }
 serde = "1"
 sha2 = "0.11.0-pre.4"
 slug = "0.1"
-sqlx = { version = "0.8", default-features = false, features = ["macros", "json", "runtime-tokio", "sqlite", "chrono"] }
+sqlx = { version = "0.8", default-features = false, features = ["macros", "json", "runtime-tokio", "sqlite", "postgres", "chrono"] }
 subtle = "2"
 syn = { version = "2", features = ["full", "extra-traits"] }
 sync_wrapper = "1"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ built on top of [axum](https://github.com/tokio-rs/axum).
 * **Secure by default** — security should be opt-out, not opt-in. Flareon takes care of making your web apps secure by
   default, defending it against common modern web vulnerabilities. You can focus on building your app, not securing it.
 
+## Development
+
+### Testing
+
+Tests that require using external databases are ignored by default. In order to run them, execute the following in the
+root of the repository:
+
+```shell
+docker compose up -d
+cargo test --all-features -- --include-ignored
+```
+
+You can them execute the following command to stop the database:
+
+```shell
+docker compose down
+```
+
 ## License
 
 Flareon is licensed under either of the following, at your option:

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: flareon-postgres
+    restart: always
+    environment:
+      POSTGRES_USER: flareon
+      POSTGRES_PASSWORD: flareon
+    ports:
+      - "5432:5432"

--- a/flareon-cli/src/migration_generator.rs
+++ b/flareon-cli/src/migration_generator.rs
@@ -540,13 +540,14 @@ impl AppState {
 ///
 /// For instance, for `use std::collections::HashMap;` the `VisibleSymbol `
 /// would be:
-///
 /// ```ignore
+/// # /*
 /// VisibleSymbol {
 ///     alias: "HashMap",
 ///     full_path: "std::collections::HashMap",
 ///     kind: VisibleSymbolKind::Use,
 /// }
+/// # */
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct VisibleSymbol {

--- a/flareon-macros/src/dbtest.rs
+++ b/flareon-macros/src/dbtest.rs
@@ -1,0 +1,44 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::ItemFn;
+
+pub(super) fn fn_to_dbtest(test_function_decl: ItemFn) -> syn::Result<TokenStream> {
+    let test_fn = &test_function_decl.sig.ident;
+    let sqlite_ident = format_ident!("{}_sqlite", test_fn);
+    let postgres_ident = format_ident!("{}_postgres", test_fn);
+
+    if test_function_decl.sig.inputs.len() != 1 {
+        return Err(syn::Error::new_spanned(
+            test_function_decl.sig.inputs,
+            "Database test function must have exactly one argument",
+        ));
+    }
+
+    let result = quote! {
+        #[::tokio::test]
+        async fn #sqlite_ident() {
+            let mut database = flareon::test::TestDatabase::new_sqlite().await.unwrap();
+
+            #test_fn(&mut database).await;
+
+            database.cleanup().await.unwrap();
+
+            #test_function_decl
+        }
+
+        #[ignore]
+        #[::tokio::test]
+        async fn #postgres_ident() {
+            let mut database = flareon::test::TestDatabase::new_postgres(stringify!(#test_fn))
+                .await
+                .unwrap();
+
+            #test_fn(&mut database).await;
+
+            database.cleanup().await.unwrap();
+
+            #test_function_decl
+        }
+    };
+    Ok(result)
+}

--- a/flareon-macros/src/lib.rs
+++ b/flareon-macros/src/lib.rs
@@ -1,3 +1,4 @@
+mod dbtest;
 mod form;
 mod model;
 mod query;
@@ -7,8 +8,9 @@ use darling::Error;
 use proc_macro::TokenStream;
 use proc_macro_crate::crate_name;
 use quote::quote;
-use syn::parse_macro_input;
+use syn::{parse_macro_input, ItemFn};
 
+use crate::dbtest::fn_to_dbtest;
 use crate::form::impl_form_for_struct;
 use crate::model::impl_model_for_struct;
 use crate::query::{query_to_tokens, Query};
@@ -110,6 +112,14 @@ pub fn model(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn query(input: TokenStream) -> TokenStream {
     let query_input = parse_macro_input!(input as Query);
     query_to_tokens(query_input).into()
+}
+
+#[proc_macro_attribute]
+pub fn dbtest(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let fn_input = parse_macro_input!(input as ItemFn);
+    fn_to_dbtest(fn_input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 pub(crate) fn flareon_ident() -> proc_macro2::TokenStream {

--- a/flareon/src/auth.rs
+++ b/flareon/src/auth.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
 use flareon::config::SecretKey;
+use flareon::db::impl_postgres::PostgresValueRef;
 #[cfg(test)]
 use mockall::automock;
 use password_auth::VerifyError;
@@ -408,6 +409,10 @@ impl DatabaseField for PasswordHash {
 
 impl FromDbValue for PasswordHash {
     fn from_sqlite(value: SqliteValueRef) -> flareon::db::Result<Self> {
+        PasswordHash::new(value.get::<String>()?).map_err(flareon::db::DatabaseError::value_decode)
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> flareon::db::Result<Self> {
         PasswordHash::new(value.get::<String>()?).map_err(flareon::db::DatabaseError::value_decode)
     }
 }

--- a/flareon/src/auth/db.rs
+++ b/flareon/src/auth/db.rs
@@ -84,13 +84,14 @@ impl DatabaseUser {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> flareon::Result<()> {
-    /// #     use flareon::test::{TestDatabaseBuilder, TestRequestBuilder};
+    /// #     use flareon::test::{TestDatabase, TestRequestBuilder};
+    /// #     let mut test_database = TestDatabase::new_sqlite().await?;
+    /// #     test_database.with_auth().run_migrations().await;
     /// #     let request = TestRequestBuilder::get("/")
-    /// #         .with_db_auth(std::sync::Arc::new(
-    /// #             TestDatabaseBuilder::new().with_auth().build().await,
-    /// #         ))
+    /// #         .with_db_auth(test_database.database())
     /// #         .build();
     /// #     view(&request).await?;
+    /// #     test_database.cleanup().await?;
     /// #     Ok(())
     /// # }
     /// ```

--- a/flareon/src/db/fields.rs
+++ b/flareon/src/db/fields.rs
@@ -2,8 +2,8 @@ use flareon::db::DatabaseField;
 use sea_query::Value;
 
 use crate::db::{
-    ColumnType, DatabaseError, FromDbValue, LimitedString, Result, SqliteValueRef, SqlxValueRef,
-    ToDbValue,
+    ColumnType, DatabaseError, FromDbValue, LimitedString, PostgresValueRef, Result,
+    SqliteValueRef, SqlxValueRef, ToDbValue,
 };
 
 macro_rules! impl_db_field {
@@ -16,10 +16,18 @@ macro_rules! impl_db_field {
             fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
                 value.get::<$ty>()
             }
+
+            fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+                value.get::<$ty>()
+            }
         }
 
         impl FromDbValue for Option<$ty> {
             fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+                value.get::<Option<$ty>>()
+            }
+
+            fn from_postgres(value: PostgresValueRef) -> Result<Self> {
                 value.get::<Option<$ty>>()
             }
         }
@@ -38,15 +46,127 @@ macro_rules! impl_db_field {
     };
 }
 
+macro_rules! impl_db_field_unsigned {
+    ($ty:ty, $signed_ty:ty, $column_type:ident) => {
+        impl DatabaseField for $ty {
+            const TYPE: ColumnType = ColumnType::$column_type;
+        }
+
+        impl FromDbValue for $ty {
+            fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+                value.get::<$ty>()
+            }
+
+            fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+                value.get::<$signed_ty>().map(|v| v as $ty)
+            }
+        }
+
+        impl FromDbValue for Option<$ty> {
+            fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+                value.get::<Option<$ty>>()
+            }
+
+            fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+                value
+                    .get::<Option<$signed_ty>>()
+                    .map(|v| v.map(|v| v as $ty))
+            }
+        }
+
+        impl ToDbValue for $ty {
+            fn to_sea_query_value(&self) -> Value {
+                self.clone().into()
+            }
+        }
+
+        impl ToDbValue for Option<$ty> {
+            fn to_sea_query_value(&self) -> Value {
+                self.clone().into()
+            }
+        }
+    };
+}
+
+impl DatabaseField for i8 {
+    const TYPE: ColumnType = ColumnType::TinyInteger;
+}
+
+impl FromDbValue for i8 {
+    fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+        value.get::<i8>()
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+        value.get::<i16>().map(|v| v as i8)
+    }
+}
+
+impl FromDbValue for Option<i8> {
+    fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+        value.get::<Option<i8>>()
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+        value.get::<Option<i16>>().map(|v| v.map(|v| v as i8))
+    }
+}
+
+impl ToDbValue for i8 {
+    fn to_sea_query_value(&self) -> Value {
+        (*self).into()
+    }
+}
+
+impl ToDbValue for Option<i8> {
+    fn to_sea_query_value(&self) -> Value {
+        (*self).into()
+    }
+}
+
+impl DatabaseField for u8 {
+    const TYPE: ColumnType = ColumnType::TinyUnsignedInteger;
+}
+
+impl FromDbValue for u8 {
+    fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+        value.get::<u8>()
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+        value.get::<i16>().map(|v| v as u8)
+    }
+}
+
+impl FromDbValue for Option<u8> {
+    fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+        value.get::<Option<u8>>()
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> Result<Self> {
+        value.get::<Option<i16>>().map(|v| v.map(|v| v as u8))
+    }
+}
+
+impl ToDbValue for u8 {
+    fn to_sea_query_value(&self) -> Value {
+        (*self).into()
+    }
+}
+
+impl ToDbValue for Option<u8> {
+    fn to_sea_query_value(&self) -> Value {
+        (*self).into()
+    }
+}
+
 impl_db_field!(bool, Boolean);
-impl_db_field!(i8, TinyInteger);
 impl_db_field!(i16, SmallInteger);
 impl_db_field!(i32, Integer);
 impl_db_field!(i64, BigInteger);
-impl_db_field!(u8, TinyUnsignedInteger);
-impl_db_field!(u16, SmallUnsignedInteger);
-impl_db_field!(u32, UnsignedInteger);
-impl_db_field!(u64, BigUnsignedInteger);
+impl_db_field_unsigned!(u16, i16, SmallUnsignedInteger);
+impl_db_field_unsigned!(u32, i32, UnsignedInteger);
+impl_db_field_unsigned!(u64, i64, BigUnsignedInteger);
 impl_db_field!(f32, Float);
 impl_db_field!(f64, Double);
 impl_db_field!(chrono::NaiveDate, Date);
@@ -82,6 +202,11 @@ impl<const LIMIT: u32> DatabaseField for LimitedString<LIMIT> {
 
 impl<const LIMIT: u32> FromDbValue for LimitedString<LIMIT> {
     fn from_sqlite(value: SqliteValueRef) -> Result<Self> {
+        let str = value.get::<String>()?;
+        Self::new(str).map_err(DatabaseError::value_decode)
+    }
+
+    fn from_postgres(value: PostgresValueRef) -> Result<Self> {
         let str = value.get::<String>()?;
         Self::new(str).map_err(DatabaseError::value_decode)
     }

--- a/flareon/src/db/impl_postgres.rs
+++ b/flareon/src/db/impl_postgres.rs
@@ -1,0 +1,182 @@
+use derive_more::Debug;
+use flareon::db::{SqlxRowRef, SqlxValueRef};
+use log::debug;
+use sea_query::{PostgresQueryBuilder, SchemaStatementBuilder};
+use sea_query_binder::{SqlxBinder, SqlxValues};
+use sqlx::{Database, PgPool, Row};
+
+use super::{Result, RowsNum, StatementResult};
+
+#[derive(Debug)]
+pub(super) struct DatabasePostgres {
+    db_connection: PgPool,
+}
+
+impl DatabasePostgres {
+    pub(super) async fn new(url: &str) -> Result<Self> {
+        let db_connection = PgPool::connect(url).await?;
+
+        Ok(Self { db_connection })
+    }
+
+    pub(super) async fn close(&self) -> Result<()> {
+        self.db_connection.close().await;
+        Ok(())
+    }
+
+    pub(super) async fn fetch_option<T: SqlxBinder>(
+        &self,
+        statement: &T,
+    ) -> Result<Option<PostgresRow>> {
+        let (sql, values) = Self::build_sql(statement);
+
+        let row = Self::sqlx_query_with(&sql, values)
+            .fetch_optional(&self.db_connection)
+            .await?;
+        Ok(row.map(PostgresRow::new))
+    }
+
+    pub(super) async fn fetch_all<T: SqlxBinder>(&self, statement: &T) -> Result<Vec<PostgresRow>> {
+        let (sql, values) = Self::build_sql(statement);
+
+        let result = Self::sqlx_query_with(&sql, values)
+            .fetch_all(&self.db_connection)
+            .await?
+            .into_iter()
+            .map(PostgresRow::new)
+            .collect();
+        Ok(result)
+    }
+
+    pub(super) async fn execute_statement<T: SqlxBinder>(
+        &self,
+        statement: &T,
+    ) -> Result<StatementResult> {
+        let (sql, mut values) = Self::build_sql(statement);
+        Self::prepare_values(&mut values);
+
+        debug!("Postgres Query: `{}` (values: {:?})", sql, values);
+
+        self.execute_sqlx(Self::sqlx_query_with(&sql, values)).await
+    }
+
+    pub(super) async fn execute_schema<T: SchemaStatementBuilder>(
+        &self,
+        statement: T,
+    ) -> Result<StatementResult> {
+        let sql = statement.build(PostgresQueryBuilder);
+        debug!("Schema modification: {}", sql);
+
+        self.execute_sqlx(sqlx::query(&sql)).await
+    }
+
+    pub(super) async fn raw_with(&self, sql: &str, values: SqlxValues) -> Result<StatementResult> {
+        self.execute_sqlx(Self::sqlx_query_with(sql, values)).await
+    }
+
+    async fn execute_sqlx<'a, A>(
+        &self,
+        sqlx_statement: sqlx::query::Query<'a, sqlx::postgres::Postgres, A>,
+    ) -> Result<StatementResult>
+    where
+        A: 'a + sqlx::IntoArguments<'a, sqlx::postgres::Postgres>,
+    {
+        let result = sqlx_statement.execute(&self.db_connection).await?;
+        let result = StatementResult {
+            rows_affected: RowsNum(result.rows_affected()),
+        };
+
+        debug!("Rows affected: {}", result.rows_affected.0);
+        Ok(result)
+    }
+
+    fn build_sql<T>(statement: &T) -> (String, SqlxValues)
+    where
+        T: SqlxBinder,
+    {
+        let (sql, values) = statement.build_sqlx(PostgresQueryBuilder);
+        debug!("Postgres Query: `{}` (values: {:?})", sql, values);
+
+        (sql, values)
+    }
+
+    fn sqlx_query_with(
+        sql: &str,
+        mut values: SqlxValues,
+    ) -> sqlx::query::Query<'_, sqlx::postgres::Postgres, SqlxValues> {
+        Self::prepare_values(&mut values);
+        sqlx::query_with(sql, values)
+    }
+
+    fn prepare_values(values: &mut SqlxValues) {
+        for value in &mut values.0 .0 {
+            Self::tinyint_to_smallint(value);
+            Self::unsigned_to_signed(value);
+        }
+    }
+
+    /// PostgreSQL does only support 2+ bytes integers, so we need to convert
+    /// i8/u8 to i16/u16. Otherwise, sqlx will convert them internally to `char`
+    /// and we'll get an error.
+    fn tinyint_to_smallint(value: &mut sea_query::Value) {
+        if let sea_query::Value::TinyInt(num) = value {
+            *value = sea_query::Value::SmallInt(num.map(|v| v as i16));
+        } else if let sea_query::Value::TinyUnsigned(num) = value {
+            *value = sea_query::Value::SmallInt(num.map(|v| v as i16));
+        }
+    }
+
+    /// PostgreSQL doesn't support unsigned integers, so we need to convert them
+    /// to signed integers.
+    fn unsigned_to_signed(value: &mut sea_query::Value) {
+        if let sea_query::Value::SmallUnsigned(num) = value {
+            *value = sea_query::Value::SmallInt(num.map(|v| v as i16));
+        } else if let sea_query::Value::Unsigned(num) = value {
+            *value = sea_query::Value::Int(num.map(|v| v as i32));
+        } else if let sea_query::Value::BigUnsigned(num) = value {
+            *value = sea_query::Value::BigInt(num.map(|v| v as i64));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PostgresRow {
+    #[debug("...")]
+    inner: sqlx::postgres::PgRow,
+}
+
+impl PostgresRow {
+    #[must_use]
+    fn new(inner: sqlx::postgres::PgRow) -> Self {
+        Self { inner }
+    }
+}
+
+impl SqlxRowRef for PostgresRow {
+    type ValueRef<'r> = PostgresValueRef<'r>;
+
+    fn get_raw(&self, index: usize) -> Result<Self::ValueRef<'_>> {
+        Ok(PostgresValueRef::new(self.inner.try_get_raw(index)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct PostgresValueRef<'r> {
+    #[debug("...")]
+    inner: sqlx::postgres::PgValueRef<'r>,
+}
+
+impl<'r> PostgresValueRef<'r> {
+    #[must_use]
+    fn new(inner: sqlx::postgres::PgValueRef<'r>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'r> SqlxValueRef<'r> for PostgresValueRef<'r> {
+    type DB = sqlx::Postgres;
+
+    fn get_raw(self) -> <Self::DB as Database>::ValueRef<'r> {
+        self.inner
+    }
+}

--- a/flareon/src/db/impl_sqlite.rs
+++ b/flareon/src/db/impl_sqlite.rs
@@ -19,18 +19,9 @@ impl DatabaseSqlite {
         Ok(Self { db_connection })
     }
 
-    pub(super) async fn close(self) -> Result<()> {
+    pub(super) async fn close(&self) -> Result<()> {
         self.db_connection.close().await;
         Ok(())
-    }
-
-    pub(super) async fn fetch_one<T: SqlxBinder>(&self, statement: &T) -> Result<SqliteRow> {
-        let (sql, values) = Self::build_sql(statement);
-
-        let row = sqlx::query_with(&sql, values)
-            .fetch_one(&self.db_connection)
-            .await?;
-        Ok(SqliteRow::new(row))
     }
 
     pub(super) async fn fetch_option<T: SqlxBinder>(
@@ -74,6 +65,10 @@ impl DatabaseSqlite {
         debug!("Schema modification: {}", sql);
 
         self.execute_sqlx(sqlx::query(&sql)).await
+    }
+
+    pub(super) async fn raw_with(&self, sql: &str, values: SqlxValues) -> Result<StatementResult> {
+        self.execute_sqlx(sqlx::query_with(sql, values)).await
     }
 
     async fn execute_sqlx<'a, A>(

--- a/flareon/src/db/migrations.rs
+++ b/flareon/src/db/migrations.rs
@@ -635,10 +635,11 @@ const CREATE_APPLIED_MIGRATIONS_MIGRATION: Operation = Operation::create_model()
 
 #[cfg(test)]
 mod tests {
+    use flareon::test::TestDatabase;
     use sea_query::ColumnSpec;
 
     use super::*;
-    use crate::db::{ColumnType, Database, DatabaseField, Identifier};
+    use crate::db::{ColumnType, DatabaseField, Identifier};
 
     struct TestMigration;
 
@@ -656,12 +657,11 @@ mod tests {
             .build()];
     }
 
-    #[tokio::test]
-    async fn test_migration_engine_run() {
+    #[flareon_macros::dbtest]
+    async fn test_migration_engine_run(test_db: &mut TestDatabase) {
         let engine = MigrationEngine::new([TestMigration]);
-        let database = Database::new("sqlite::memory:").await.unwrap();
 
-        let result = engine.run(&database).await;
+        let result = engine.run(&test_db.database()).await;
 
         assert!(result.is_ok());
     }

--- a/flareon/src/lib.rs
+++ b/flareon/src/lib.rs
@@ -606,6 +606,7 @@ where
     context.apps = apps;
 
     let context = Arc::new(context);
+    let context_cleanup = context.clone();
 
     let handler = |axum_request: axum::extract::Request| async move {
         let request = request_axum_to_flareon(axum_request, Arc::clone(&context));
@@ -663,6 +664,9 @@ where
         .map_err(|e| ErrorRepr::StartServer { source: e })?;
     if config::REGISTER_PANIC_HOOK {
         let _ = std::panic::take_hook();
+    }
+    if let Some(database) = &context_cleanup.database {
+        database.close().await?;
     }
 
     Ok(())

--- a/flareon/tests/db.rs
+++ b/flareon/tests/db.rs
@@ -6,56 +6,55 @@ use fake::{Dummy, Fake, Faker};
 use flareon::db::migrations::{Field, Operation};
 use flareon::db::query::ExprEq;
 use flareon::db::{model, query, Database, DatabaseField, Identifier, LimitedString, Model};
+use flareon::test::TestDatabase;
 
-#[tokio::test]
-async fn model_crud() {
-    let db = test_sqlite_db().await;
+#[flareon_macros::dbtest]
+async fn model_crud(test_db: &mut TestDatabase) {
+    migrate_test_model(&*test_db).await;
 
-    migrate_test_model(&db).await;
-
-    assert_eq!(TestModel::objects().all(&db).await.unwrap(), vec![]);
+    assert_eq!(TestModel::objects().all(&**test_db).await.unwrap(), vec![]);
 
     let mut model = TestModel {
         id: 0,
         name: "test".to_owned(),
     };
-    model.save(&db).await.unwrap();
-    let objects = TestModel::objects().all(&db).await.unwrap();
+    model.save(&**test_db).await.unwrap();
+    let objects = TestModel::objects().all(&**test_db).await.unwrap();
     assert_eq!(objects.len(), 1);
     assert_eq!(objects[0].name, "test");
 
     TestModel::objects()
         .filter(<TestModel as Model>::Fields::id.eq(1))
-        .delete(&db)
+        .delete(&**test_db)
         .await
         .unwrap();
 
-    assert_eq!(TestModel::objects().all(&db).await.unwrap(), vec![]);
-
-    db.close().await.unwrap();
+    assert_eq!(TestModel::objects().all(&**test_db).await.unwrap(), vec![]);
 }
 
-#[tokio::test]
-async fn model_macro_filtering() {
-    let db = test_sqlite_db().await;
+#[flareon_macros::dbtest]
+async fn model_macro_filtering(test_db: &mut TestDatabase) {
+    migrate_test_model(&*test_db).await;
 
-    migrate_test_model(&db).await;
-
-    assert_eq!(TestModel::objects().all(&db).await.unwrap(), vec![]);
+    assert_eq!(TestModel::objects().all(&**test_db).await.unwrap(), vec![]);
 
     let mut model = TestModel {
         id: 0,
         name: "test".to_owned(),
     };
-    model.save(&db).await.unwrap();
-    let objects = query!(TestModel, $name == "test").all(&db).await.unwrap();
+    model.save(&**test_db).await.unwrap();
+    let objects = query!(TestModel, $name == "test")
+        .all(&**test_db)
+        .await
+        .unwrap();
     assert_eq!(objects.len(), 1);
     assert_eq!(objects[0].name, "test");
 
-    let objects = query!(TestModel, $name == "t").all(&db).await.unwrap();
+    let objects = query!(TestModel, $name == "t")
+        .all(&**test_db)
+        .await
+        .unwrap();
     assert!(objects.is_empty());
-
-    db.close().await.unwrap();
 }
 
 #[derive(Debug, PartialEq)]
@@ -118,6 +117,7 @@ struct AllFieldsModel {
     field_date: chrono::NaiveDate,
     field_time: chrono::NaiveTime,
     field_datetime: chrono::NaiveDateTime,
+    #[dummy(faker = "fake::chrono::Precision::<6>")]
     field_datetime_timezone: chrono::DateTime<chrono::FixedOffset>,
     field_string: String,
     field_blob: Vec<u8>,
@@ -157,30 +157,34 @@ const CREATE_ALL_FIELDS_MODEL: Operation = Operation::create_model()
     ])
     .build();
 
-#[tokio::test]
-async fn all_fields_model() {
-    let db = test_sqlite_db().await;
-
+#[flareon_macros::dbtest]
+async fn all_fields_model(db: &mut TestDatabase) {
     migrate_all_fields_model(&db).await;
 
-    assert_eq!(AllFieldsModel::objects().all(&db).await.unwrap(), vec![]);
+    assert_eq!(AllFieldsModel::objects().all(&**db).await.unwrap(), vec![]);
 
     let r = &mut StdRng::seed_from_u64(123_785);
     let mut models = (0..100)
         .map(|_| Faker.fake_with_rng(r))
         .collect::<Vec<AllFieldsModel>>();
     for model in &mut models {
-        model.save(&db).await.unwrap();
+        model.save(&**db).await.unwrap();
     }
 
-    let mut models_from_db: Vec<_> = AllFieldsModel::objects().all(&db).await.unwrap();
+    let mut models_from_db: Vec<_> = AllFieldsModel::objects().all(&**db).await.unwrap();
     models_from_db.iter_mut().for_each(|model| model.id = 0);
+    normalize_datetimes(&mut models);
+    normalize_datetimes(&mut models_from_db);
 
-    assert_eq!(models, models_from_db);
-
-    db.close().await.unwrap();
+    assert_eq!(models.len(), models_from_db.len());
+    assert!(models.iter().all(|model| models_from_db.contains(model)));
 }
 
-async fn test_sqlite_db() -> Database {
-    Database::new("sqlite::memory:").await.unwrap()
+/// Normalize the datetimes to UTC.
+fn normalize_datetimes(data: &mut Vec<AllFieldsModel>) {
+    for model in data {
+        model.field_datetime_timezone = model.field_datetime_timezone.with_timezone(
+            &chrono::FixedOffset::east_opt(0).expect("UTC timezone is always valid"),
+        );
+    }
 }


### PR DESCRIPTION
In addition to that, this also adds tests that use Postgres, and a way to run raw SQL queries.

There's some opportunity to do some deduplication between Sqlite and Postgres code, but let's wait for it until MySQL support lands.