### PR TITLE
chore: remove unused dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,15 +241,11 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -270,7 +266,6 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -396,10 +391,7 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "serde",
- "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -441,7 +433,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -668,7 +660,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -890,7 +881,6 @@ dependencies = [
  "mockall",
  "password-auth",
  "pin-project-lite",
- "regex",
  "sea-query",
  "sea-query-binder",
  "serde",
@@ -994,7 +984,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1074,7 +1063,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1145,12 +1133,6 @@ checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1278,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1297,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1939,7 +1921,6 @@ checksum = "ff504d13b5e4b52fffcf2fb203d0352a5722fa5151696db768933e41e1e591bb"
 dependencies = [
  "chrono",
  "inherent",
- "sea-query-derive",
 ]
 
 [[package]]
@@ -1951,20 +1932,6 @@ dependencies = [
  "chrono",
  "sea-query",
  "sqlx",
-]
-
-[[package]]
-name = "sea-query-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9834af2c4bd8c5162f00c89f1701fb6886119a88062cf76fe842ea9e232b9839"
-dependencies = [
- "darling",
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn",
- "thiserror 1.0.66",
 ]
 
 [[package]]
@@ -1996,16 +1963,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
-dependencies = [
- "itoa",
  "serde",
 ]
 
@@ -2210,7 +2167,7 @@ checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.5.0",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2585,7 +2542,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2642,7 +2598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6abbfcaf6436ec5a772cd9f965401da12db793e404ae6134eac066fa5a04f3"
 dependencies = [
  "async-trait",
- "axum-core",
  "base64",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,26 +23,26 @@ askama_derive = "0.12.5"
 askama_parser = "0.2.1"
 async-stream = "0.3"
 async-trait = "0.1"
-axum = "0.7"
+axum = { version = "0.7", default-features = false }
 backtrace = "0.3"
 bytes = "1.7"
 cargo_toml = "0.20"
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive", "env"] }
+chrono = { version = "0.4", default-features = false }
+clap = "4"
 clap-verbosity-flag = "2"
 convert_case = "0.6"
 darling = "0.20"
 derive_builder = "0.20"
-derive_more = { version = "1", features = ["full"] }
+derive_more = "1"
 env_logger = "0.11"
-fake = { version = "3", features = ["derive", "chrono"] }
+fake = "3"
 flareon = { path = "flareon" }
 flareon_codegen = { path = "flareon-codegen" }
 flareon_macros = { path = "flareon-macros" }
 form_urlencoded = "1"
-futures = "0.3"
-futures-core = "0.3"
-futures-util = "0.3"
+futures = { version = "0.3", default-features = false }
+futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 glob = "0.3"
 hmac = "0.13.0-pre.4"
 http = "1.1"
@@ -51,30 +51,29 @@ http-body-util = "0.1"
 indexmap = "2"
 itertools = "0.13"
 log = "0.4"
-mime_guess = "2"
+mime_guess = { version = "2", default-features = false }
 mockall = "0.13"
-password-auth = "1.1.0-pre.1"
+password-auth = { version = "1.1.0-pre.1", default-features = false }
 pin-project-lite = "0.2"
 prettyplease = "0.2"
 proc-macro-crate = "3"
-proc-macro2 = "1"
-quote = "1"
+proc-macro2 = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
 rand = "0.8"
-regex = "1.11"
 rustversion = "1"
-sea-query = "0.32.0-rc.2"
-sea-query-binder = { version = "0.7.0-rc.2", features = ["sqlx-sqlite", "sqlx-postgres", "with-chrono", "runtime-tokio"] }
+sea-query = { version = "0.32.0-rc.2", default-features = false }
+sea-query-binder = { version = "0.7.0-rc.2", default-features = false }
 serde = "1"
 sha2 = "0.11.0-pre.4"
 slug = "0.1"
-sqlx = { version = "0.8", default-features = false, features = ["macros", "json", "runtime-tokio", "sqlite", "postgres", "chrono"] }
-subtle = "2"
-syn = { version = "2", features = ["full", "extra-traits"] }
+sqlx = { version = "0.8", default-features = false }
+subtle = { version = "2", default-features = false }
+syn = { version = "2", default-features = false }
 sync_wrapper = "1"
 tempfile = "3"
 thiserror = "2"
-time = "0.3.35"
-tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
+time = { version = "0.3.35", default-features = false }
+tokio = { version = "1.40", default-features = false }
 tower = "0.5.1"
-tower-sessions = "0.13"
+tower-sessions = { version = "0.13", default-features = false }
 trybuild = { version = "1", features = ["diff"] }

--- a/flareon-cli/Cargo.toml
+++ b/flareon-cli/Cargo.toml
@@ -9,7 +9,7 @@ description = "Modern web framework focused on speed and ease of use - CLI tool.
 anyhow.workspace = true
 cargo_toml.workspace = true
 chrono.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
 clap-verbosity-flag.workspace = true
 darling.workspace = true
 env_logger.workspace = true

--- a/flareon-macros/Cargo.toml
+++ b/flareon-macros/Cargo.toml
@@ -16,8 +16,8 @@ path = "tests/compile_tests.rs"
 darling.workspace = true
 flareon_codegen.workspace = true
 proc-macro-crate.workspace = true
-proc-macro2.workspace = true
-quote.workspace = true
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, features = ["proc-macro"] }
 syn.workspace = true
 
 [dev-dependencies]

--- a/flareon/Cargo.toml
+++ b/flareon/Cargo.toml
@@ -10,13 +10,13 @@ askama.workspace = true
 askama_derive.workspace = true
 askama_parser.workspace = true
 async-trait.workspace = true
-axum.workspace = true
+axum = { workspace = true, features = ["http1", "tokio"] }
 backtrace.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 derive_builder.workspace = true
-derive_more.workspace = true
-fake = { workspace = true, optional = true }
+derive_more = { workspace = true, features = ["debug", "deref", "display", "from"] }
+fake = { workspace = true, optional = true, features = ["derive", "chrono"] }
 flareon_macros.workspace = true
 form_urlencoded.workspace = true
 futures-core.workspace = true
@@ -28,27 +28,26 @@ http-body-util.workspace = true
 indexmap.workspace = true
 log.workspace = true
 mime_guess.workspace = true
-mockall.workspace = true
-password-auth.workspace = true
+password-auth = { workspace = true, features = ["std", "argon2"] }
 pin-project-lite.workspace = true
-regex.workspace = true
-sea-query-binder.workspace = true
-sea-query.workspace = true
+sea-query = { workspace = true, features = ["backend-sqlite", "backend-postgres"] }
+sea-query-binder = { workspace = true, features = ["sqlx-sqlite", "sqlx-postgres", "with-chrono", "runtime-tokio"] }
 serde.workspace = true
 sha2.workspace = true
-sqlx.workspace = true
-subtle.workspace = true
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "postgres", "chrono"] }
+subtle = { workspace = true, features = ["std"] }
 sync_wrapper.workspace = true
 thiserror.workspace = true
 time.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower.workspace = true
-tower-sessions.workspace = true
+tower-sessions = { workspace = true, features = ["memory-store"] }
 
 [dev-dependencies]
 async-stream.workspace = true
 fake.workspace = true
 futures.workspace = true
+mockall.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = [


### PR DESCRIPTION
This also removes the `regex` dependency as it was easily replaced with some simple text-handling code.

This PR reduces the number of compiled units for the examples/sessions crate from 312 to 252. This allows me to reduce the clean build time from 22.7 seconds to 18.8 seconds on my laptop.

![image](https://github.com/user-attachments/assets/be0846af-eff9-452f-b216-bea22e53243b)
