### PR TITLE
docs: enable nightly-only docsrs

### DIFF
--- a/flareon/Cargo.toml
+++ b/flareon/Cargo.toml
@@ -52,6 +52,10 @@ fake.workspace = true
 futures.workspace = true
 mockall.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [package.metadata.cargo-machete]
 ignored = [
     # askama doesn't seem to be working with minimal versions of its dependencies at the moment,

--- a/flareon/src/lib.rs
+++ b/flareon/src/lib.rs
@@ -41,6 +41,7 @@
     unused_import_braces,
     unused_qualifications
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 extern crate self as flareon;
 


### PR DESCRIPTION
See rust-lang/rust#43781. This enables infoboxes like "Available on crate feature XXX only." in the documentation generated using `cargo doc` on nightly, or by building on docs.rs.

This can be tested with:

```shell
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features
```