### PR TITLE
feat: implement flareon::main macro for easy framework bootstrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,7 @@ dependencies = [
 name = "example-admin"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "flareon",
- "tokio",
 ]
 
 [[package]]
@@ -810,7 +808,6 @@ name = "example-hello-world"
 version = "0.1.0"
 dependencies = [
  "flareon",
- "tokio",
 ]
 
 [[package]]
@@ -819,7 +816,6 @@ version = "0.1.0"
 dependencies = [
  "askama",
  "flareon",
- "tokio",
 ]
 
 [[package]]
@@ -827,9 +823,7 @@ name = "example-todo-list"
 version = "0.1.0"
 dependencies = [
  "askama",
- "env_logger",
  "flareon",
- "tokio",
 ]
 
 [[package]]

--- a/examples/admin/Cargo.toml
+++ b/examples/admin/Cargo.toml
@@ -6,6 +6,4 @@ description = "Admin panel - Flareon example."
 edition = "2021"
 
 [dependencies]
-env_logger = "0.11.5"
 flareon = { path = "../../flareon" }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/admin/src/main.rs
+++ b/examples/admin/src/main.rs
@@ -36,10 +36,8 @@ impl FlareonApp for HelloApp {
     }
 }
 
-#[tokio::main]
-async fn main() {
-    env_logger::init();
-
+#[flareon::main]
+async fn main() -> flareon::Result<FlareonProject> {
     let flareon_project = FlareonProject::builder()
         .config(
             ProjectConfig::builder()
@@ -57,10 +55,7 @@ async fn main() {
         .middleware_with_context(StaticFilesMiddleware::from_app_context)
         .middleware(SessionMiddleware::new())
         .build()
-        .await
-        .unwrap();
+        .await?;
 
-    flareon::run(flareon_project, "127.0.0.1:8000")
-        .await
-        .unwrap();
+    Ok(flareon_project)
 }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 flareon = { path = "../../flareon" }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -22,15 +22,12 @@ impl FlareonApp for HelloApp {
     }
 }
 
-#[tokio::main]
-async fn main() {
+#[flareon::main]
+async fn main() -> flareon::Result<FlareonProject> {
     let flareon_project = FlareonProject::builder()
         .register_app_with_views(HelloApp, "")
         .build()
-        .await
-        .unwrap();
+        .await?;
 
-    flareon::run(flareon_project, "127.0.0.1:8000")
-        .await
-        .unwrap();
+    Ok(flareon_project)
 }

--- a/examples/sessions/Cargo.toml
+++ b/examples/sessions/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 [dependencies]
 askama = "0.12.1"
 flareon = { path = "../../flareon" }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/sessions/src/main.rs
+++ b/examples/sessions/src/main.rs
@@ -82,16 +82,13 @@ impl FlareonApp for HelloApp {
     }
 }
 
-#[tokio::main]
-async fn main() {
+#[flareon::main]
+async fn main() -> flareon::Result<FlareonProject> {
     let flareon_project = FlareonProject::builder()
         .register_app_with_views(HelloApp, "")
         .middleware(SessionMiddleware::new())
         .build()
-        .await
-        .unwrap();
+        .await?;
 
-    flareon::run(flareon_project, "127.0.0.1:8000")
-        .await
-        .unwrap();
+    Ok(flareon_project)
 }

--- a/examples/todo-list/Cargo.toml
+++ b/examples/todo-list/Cargo.toml
@@ -8,5 +8,3 @@ edition = "2021"
 [dependencies]
 askama = "0.12.1"
 flareon = { path = "../../flareon" }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.11.5"

--- a/flareon-macros/src/lib.rs
+++ b/flareon-macros/src/lib.rs
@@ -1,5 +1,6 @@
 mod dbtest;
 mod form;
+mod main_fn;
 mod model;
 mod query;
 
@@ -12,6 +13,7 @@ use syn::{parse_macro_input, ItemFn};
 
 use crate::dbtest::fn_to_dbtest;
 use crate::form::impl_form_for_struct;
+use crate::main_fn::fn_to_flareon_main;
 use crate::model::impl_model_for_struct;
 use crate::query::{query_to_tokens, Query};
 
@@ -118,6 +120,14 @@ pub fn query(input: TokenStream) -> TokenStream {
 pub fn dbtest(_args: TokenStream, input: TokenStream) -> TokenStream {
     let fn_input = parse_macro_input!(input as ItemFn);
     fn_to_dbtest(fn_input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let fn_input = parse_macro_input!(input as ItemFn);
+    fn_to_flareon_main(fn_input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/flareon-macros/src/main_fn.rs
+++ b/flareon-macros/src/main_fn.rs
@@ -1,0 +1,40 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::ItemFn;
+
+use crate::flareon_ident;
+
+pub(super) fn fn_to_flareon_main(main_function_decl: ItemFn) -> syn::Result<TokenStream> {
+    let mut new_main_decl = main_function_decl.clone();
+    new_main_decl.sig.ident =
+        syn::Ident::new("__flareon_main", main_function_decl.sig.ident.span());
+
+    if !main_function_decl.sig.inputs.is_empty() {
+        return Err(syn::Error::new_spanned(
+            main_function_decl.sig.inputs,
+            "flareon::main function must have zero arguments",
+        ));
+    }
+
+    let crate_name = flareon_ident();
+    let result = quote! {
+        fn main() {
+            let body = async {
+                let project: #crate_name::FlareonProject = __flareon_main().await.unwrap();
+                #crate_name::run_cli(project).await.unwrap();
+
+                #new_main_decl
+            };
+            #[allow(clippy::expect_used)]
+            {
+                return #crate_name::__private::tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .expect("Failed building the Runtime")
+                    .block_on(body);
+            }
+        }
+
+    };
+    Ok(result)
+}

--- a/flareon-macros/tests/compile_tests.rs
+++ b/flareon-macros/tests/compile_tests.rs
@@ -26,3 +26,11 @@ fn func_query() {
     t.compile_fail("tests/ui/func_query_double_field.rs");
     t.compile_fail("tests/ui/func_query_invalid_field.rs");
 }
+
+#[rustversion::attr(not(nightly), ignore)]
+#[test]
+fn attr_main() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/attr_main.rs");
+    t.compile_fail("tests/ui/attr_main_args.rs");
+}

--- a/flareon-macros/tests/ui/attr_main.rs
+++ b/flareon-macros/tests/ui/attr_main.rs
@@ -1,0 +1,6 @@
+use flareon::FlareonProject;
+
+#[flareon::main]
+async fn main() -> flareon::Result<FlareonProject> {
+    std::process::exit(0);
+}

--- a/flareon-macros/tests/ui/attr_main_args.rs
+++ b/flareon-macros/tests/ui/attr_main_args.rs
@@ -1,0 +1,4 @@
+#[flareon::main]
+async fn main(arg: i32) -> flareon::Result<FlareonProject> {
+    std::process::exit(0);
+}

--- a/flareon-macros/tests/ui/attr_main_args.stderr
+++ b/flareon-macros/tests/ui/attr_main_args.stderr
@@ -1,0 +1,11 @@
+error: flareon::main function must have zero arguments
+ --> tests/ui/attr_main_args.rs:2:15
+  |
+2 | async fn main(arg: i32) -> flareon::Result<FlareonProject> {
+  |               ^^^^^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/attr_main_args.rs:4:2
+  |
+4 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/ui/attr_main_args.rs`

--- a/flareon/Cargo.toml
+++ b/flareon/Cargo.toml
@@ -43,7 +43,7 @@ sync_wrapper.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tower.workspace = true
+tower = { workspace = true, features = ["util"] }
 tower-sessions = { workspace = true, features = ["memory-store"] }
 
 [dev-dependencies]

--- a/flareon/src/private.rs
+++ b/flareon/src/private.rs
@@ -7,3 +7,4 @@
 
 pub use async_trait::async_trait;
 pub use bytes::Bytes;
+pub use tokio;

--- a/flareon/src/test.rs
+++ b/flareon/src/test.rs
@@ -17,24 +17,20 @@ use crate::db::Database;
 use crate::request::{Request, RequestExt};
 use crate::response::Response;
 use crate::router::Router;
-use crate::{AppContext, Body, Error, Result};
+use crate::{AppContext, Body, BoxedHandler, Result};
 
 /// A test client for making requests to a Flareon project.
 ///
 /// Useful for End-to-End testing Flareon projects.
 #[derive(Debug)]
-pub struct Client<S> {
+pub struct Client {
     context: Arc<AppContext>,
-    handler: S,
+    handler: BoxedHandler,
 }
 
-impl<S> Client<S>
-where
-    S: Service<Request, Response = Response, Error = Error> + Send + Sync + Clone + 'static,
-    S::Future: Send,
-{
+impl Client {
     #[must_use]
-    pub fn new(project: FlareonProject<S>) -> Self {
+    pub fn new(project: FlareonProject) -> Self {
         let (context, handler) = project.into_context();
         Self {
             context: Arc::new(context),

--- a/flareon/tests/router.rs
+++ b/flareon/tests/router.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use flareon::request::{Request, RequestExt};
 use flareon::response::{Response, ResponseExt};
-use flareon::router::{Route, Router, RouterService};
+use flareon::router::{Route, Router};
 use flareon::test::Client;
 use flareon::{Body, FlareonApp, FlareonProject, StatusCode};
 
@@ -43,7 +43,7 @@ async fn path_params() {
 }
 
 #[must_use]
-async fn project() -> FlareonProject<RouterService> {
+async fn project() -> FlareonProject {
     struct RouterApp;
     impl FlareonApp for RouterApp {
         fn name(&self) -> &'static str {


### PR DESCRIPTION
This is the first step in making Flareon an actual "framework" rather than just a library. This macro currently doesn't do much now, but eventually we'd like to have an entire CLI that would be automatically generated for each Flareon project and would allow to do some common operations (run server, run migrations, copy static files to a directory, etc.), as well as allow Flareon users to define their own ones.