### PR TITLE
feat(orm): implement dependencies for migrations

### DIFF
--- a/examples/todo-list/src/migrations/m_0001_initial.rs
+++ b/examples/todo-list/src/migrations/m_0001_initial.rs
@@ -5,6 +5,7 @@ pub(super) struct Migration;
 impl ::flareon::db::migrations::Migration for Migration {
     const APP_NAME: &'static str = "example-todo-list";
     const MIGRATION_NAME: &'static str = "m_0001_initial";
+    const DEPENDENCIES: &'static [::flareon::db::migrations::MigrationDependency] = &[];
     const OPERATIONS: &'static [::flareon::db::migrations::Operation] =
         &[::flareon::db::migrations::Operation::create_model()
             .table_name(::flareon::db::Identifier::new("todo_item"))

--- a/flareon/src/auth/db/migrations/m_0001_initial.rs
+++ b/flareon/src/auth/db/migrations/m_0001_initial.rs
@@ -5,6 +5,7 @@ pub(super) struct Migration;
 impl ::flareon::db::migrations::Migration for Migration {
     const APP_NAME: &'static str = "flareon_auth";
     const MIGRATION_NAME: &'static str = "m_0001_initial";
+    const DEPENDENCIES: &'static [::flareon::db::migrations::MigrationDependency] = &[];
     const OPERATIONS: &'static [::flareon::db::migrations::Operation] = &[
         ::flareon::db::migrations::Operation::create_model()
             .table_name(::flareon::db::Identifier::new("database_user"))

--- a/flareon/src/db.rs
+++ b/flareon/src/db.rs
@@ -54,6 +54,9 @@ pub enum DatabaseError {
     /// Error when decoding database value.
     #[error("Error when decoding database value: {0}")]
     ValueDecode(Box<dyn std::error::Error + 'static + Send + Sync>),
+    /// Error when applying migrations.
+    #[error("Error when applying migrations: {0}")]
+    MigrationError(#[from] migrations::MigrationEngineError),
 }
 
 impl DatabaseError {

--- a/flareon/src/db/migrations.rs
+++ b/flareon/src/db/migrations.rs
@@ -1,11 +1,23 @@
+mod sorter;
+
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
 use flareon_macros::{model, query};
 use log::info;
 use sea_query::{ColumnDef, StringLen};
+use thiserror::Error;
 
+use crate::db::migrations::sorter::{MigrationSorter, MigrationSorterError};
 use crate::db::{ColumnType, Database, DatabaseField, Identifier, Result};
+
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum MigrationEngineError {
+    /// An error occurred while determining the correct order of migrations.
+    #[error("Error while determining the correct order of migrations")]
+    MigrationSortError(#[from] MigrationSorterError),
+}
 
 /// A migration engine that can run migrations.
 #[derive(Debug)]
@@ -14,25 +26,27 @@ pub struct MigrationEngine {
 }
 
 impl MigrationEngine {
-    #[must_use]
-    pub fn new<T: DynMigration + 'static, V: IntoIterator<Item = T>>(migrations: V) -> Self {
+    pub fn new<T: DynMigration + 'static, V: IntoIterator<Item = T>>(
+        migrations: V,
+    ) -> Result<Self> {
         let migrations = migrations.into_iter().map(MigrationWrapper::new).collect();
         Self::from_wrapper(migrations)
     }
 
-    #[must_use]
-    pub fn from_wrapper(mut migrations: Vec<MigrationWrapper>) -> Self {
-        Self::sort_migrations(&mut migrations);
-        Self { migrations }
+    pub fn from_wrapper(mut migrations: Vec<MigrationWrapper>) -> Result<Self> {
+        Self::sort_migrations(&mut migrations)?;
+        Ok(Self { migrations })
     }
 
     /// Sorts the migrations by app name and migration name to ensure that the
     /// order of applying migrations is consistent and deterministic. Then
     /// determines the correct order of applying migrations based on the
     /// dependencies between them.
-    pub fn sort_migrations<T: DynMigration>(migrations: &mut [T]) {
-        migrations.sort_by(|a, b| (a.app_name(), a.name()).cmp(&(b.app_name(), b.name())));
-        // TODO: Determine the correct order based on the dependencies
+    pub fn sort_migrations<T: DynMigration>(migrations: &mut [T]) -> Result<()> {
+        MigrationSorter::new(migrations)
+            .sort()
+            .map_err(MigrationEngineError::from)?;
+        Ok(())
     }
 
     /// Runs the migrations. If a migration is already applied, it will be
@@ -51,7 +65,9 @@ impl MigrationEngine {
     /// # Examples
     ///
     /// ```
-    /// use flareon::db::migrations::{Field, Migration, MigrationEngine, Operation};
+    /// use flareon::db::migrations::{
+    ///     Field, Migration, MigrationDependency, MigrationEngine, Operation,
+    /// };
     /// use flareon::db::{Database, DatabaseField, Identifier};
     /// use flareon::Result;
     ///
@@ -60,6 +76,7 @@ impl MigrationEngine {
     /// impl Migration for MyMigration {
     ///     const APP_NAME: &'static str = "todoapp";
     ///     const MIGRATION_NAME: &'static str = "m_0001_initial";
+    ///     const DEPENDENCIES: &'static [MigrationDependency] = &[];
     ///     const OPERATIONS: &'static [Operation] = &[Operation::create_model()
     ///         .table_name(Identifier::new("todoapp__my_model"))
     ///         .fields(&[
@@ -73,7 +90,7 @@ impl MigrationEngine {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
-    /// let engine = MigrationEngine::new([MyMigration]);
+    /// let engine = MigrationEngine::new([MyMigration])?;
     /// let database = Database::new("sqlite::memory:").await?;
     /// engine.run(&database).await?;
     /// # Ok(())
@@ -504,12 +521,14 @@ impl AddFieldBuilder {
 pub trait Migration {
     const APP_NAME: &'static str;
     const MIGRATION_NAME: &'static str;
+    const DEPENDENCIES: &'static [MigrationDependency];
     const OPERATIONS: &'static [Operation];
 }
 
 pub trait DynMigration {
     fn app_name(&self) -> &str;
     fn name(&self) -> &str;
+    fn dependencies(&self) -> &[MigrationDependency];
     fn operations(&self) -> &[Operation];
 }
 
@@ -520,6 +539,10 @@ impl<T: Migration + Send + Sync + 'static> DynMigration for T {
 
     fn name(&self) -> &str {
         Self::MIGRATION_NAME
+    }
+
+    fn dependencies(&self) -> &[MigrationDependency] {
+        Self::DEPENDENCIES
     }
 
     fn operations(&self) -> &[Operation] {
@@ -536,6 +559,10 @@ impl DynMigration for &dyn DynMigration {
         DynMigration::name(*self)
     }
 
+    fn dependencies(&self) -> &[MigrationDependency] {
+        DynMigration::dependencies(*self)
+    }
+
     fn operations(&self) -> &[Operation] {
         DynMigration::operations(*self)
     }
@@ -548,6 +575,10 @@ impl DynMigration for Box<dyn DynMigration> {
 
     fn name(&self) -> &str {
         DynMigration::name(&**self)
+    }
+
+    fn dependencies(&self) -> &[MigrationDependency] {
+        DynMigration::dependencies(&**self)
     }
 
     fn operations(&self) -> &[Operation] {
@@ -571,6 +602,10 @@ impl DynMigration for MigrationWrapper {
 
     fn name(&self) -> &str {
         self.0.name()
+    }
+
+    fn dependencies(&self) -> &[MigrationDependency] {
+        self.0.dependencies()
     }
 
     fn operations(&self) -> &[Operation] {
@@ -613,6 +648,52 @@ impl From<ColumnType> for sea_query::ColumnType {
     }
 }
 
+/// A migration dependency: a relationship between two migrations that tells the
+/// migration engine which migrations need to be applied before
+/// others.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct MigrationDependency {
+    inner: MigrationDependencyInner,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+enum MigrationDependencyInner {
+    Migration {
+        app: &'static str,
+        migration: &'static str,
+    },
+    Model {
+        app: &'static str,
+        model_name: &'static str,
+    },
+}
+
+impl MigrationDependency {
+    #[must_use]
+    const fn new(inner: MigrationDependencyInner) -> Self {
+        Self { inner }
+    }
+
+    /// Creates a dependency on another migration.
+    ///
+    /// This ensures that the migration engine will apply the migration with
+    /// given app and migration name before the current migration.
+    #[must_use]
+    pub const fn migration(app: &'static str, migration: &'static str) -> Self {
+        Self::new(MigrationDependencyInner::Migration { app, migration })
+    }
+
+    /// Creates a dependency on a model.
+    ///
+    /// This ensures that the migration engine will apply the migration that
+    /// creates the model with the given app and model name before the current
+    /// migration.
+    #[must_use]
+    pub const fn model(app: &'static str, model_name: &'static str) -> Self {
+        Self::new(MigrationDependencyInner::Model { app, model_name })
+    }
+}
+
 #[derive(Debug)]
 #[model(table_name = "flareon__migrations", model_type = "internal")]
 struct AppliedMigration {
@@ -651,6 +732,7 @@ mod tests {
     impl Migration for TestMigration {
         const APP_NAME: &'static str = "testapp";
         const MIGRATION_NAME: &'static str = "m_0001_initial";
+        const DEPENDENCIES: &'static [MigrationDependency] = &[];
         const OPERATIONS: &'static [Operation] = &[Operation::create_model()
             .table_name(Identifier::new("testapp__test_model"))
             .fields(&[
@@ -664,7 +746,7 @@ mod tests {
 
     #[flareon_macros::dbtest]
     async fn test_migration_engine_run(test_db: &mut TestDatabase) {
-        let engine = MigrationEngine::new([TestMigration]);
+        let engine = MigrationEngine::new([TestMigration]).unwrap();
 
         let result = engine.run(&test_db.database()).await;
 

--- a/flareon/src/db/migrations/sorter.rs
+++ b/flareon/src/db/migrations/sorter.rs
@@ -1,0 +1,469 @@
+use std::collections::HashMap;
+
+use flareon::db::migrations::MigrationDependency;
+use thiserror::Error;
+
+use crate::db::migrations::{DynMigration, MigrationDependencyInner, OperationInner};
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum MigrationSorterError {
+    #[error("Cycle detected in migrations")]
+    CycleDetected,
+    #[error("Dependency not found: {}", format_migration_dependency(.0))]
+    InvalidDependency(MigrationDependency),
+    #[error("Migration defined twice: {app_name}::{migration_name}")]
+    DuplicateMigration {
+        app_name: String,
+        migration_name: String,
+    },
+    #[error("Migration creating model defined twice: {app_name}::{model_name}")]
+    DuplicateModel {
+        app_name: String,
+        model_name: String,
+    },
+}
+
+type Result<T> = core::result::Result<T, MigrationSorterError>;
+
+fn format_migration_dependency(dependency: &MigrationDependency) -> String {
+    match dependency.inner {
+        MigrationDependencyInner::Migration { app, migration } => {
+            format!("migration {app}::{migration}")
+        }
+        MigrationDependencyInner::Model { app, model_name } => {
+            format!("model {app}::{model_name}")
+        }
+    }
+}
+
+/// Sorts migrations topologically based on their dependencies.
+#[derive(Debug)]
+pub(super) struct MigrationSorter<'a, T> {
+    migrations: &'a mut [T],
+}
+
+impl<'a, T: DynMigration> MigrationSorter<'a, T> {
+    #[must_use]
+    pub(super) fn new(migrations: &'a mut [T]) -> Self {
+        Self { migrations }
+    }
+
+    pub(super) fn sort(&mut self) -> Result<()> {
+        // Sort by names to ensure that the order is deterministic
+        self.migrations
+            .sort_by(|a, b| (b.app_name(), b.name()).cmp(&(a.app_name(), a.name())));
+
+        self.toposort()?;
+        Ok(())
+    }
+
+    fn toposort(&mut self) -> Result<()> {
+        let lookup = Self::create_lookup_table(self.migrations)?;
+        let mut graph = Graph::new(self.migrations.len());
+
+        for (index, migration) in self.migrations.iter().enumerate() {
+            for dependency in migration.dependencies() {
+                let dependency_index = lookup
+                    .get(&MigrationLookup::from(dependency))
+                    .ok_or(MigrationSorterError::InvalidDependency(*dependency))?;
+                graph.add_edge(*dependency_index, index);
+            }
+        }
+
+        let mut sorted_indices = graph.toposort()?;
+        apply_permutation(self.migrations, &mut sorted_indices);
+
+        Ok(())
+    }
+
+    fn create_lookup_table(migrations: &[T]) -> Result<HashMap<MigrationLookup, usize>> {
+        let mut map = HashMap::with_capacity(migrations.len());
+
+        for (index, migration) in migrations.iter().enumerate() {
+            let app_and_name = MigrationLookup::ByAppAndName {
+                app: migration.app_name(),
+                name: migration.name(),
+            };
+            if map.insert(app_and_name, index).is_some() {
+                return Err(MigrationSorterError::DuplicateMigration {
+                    app_name: migration.app_name().to_owned(),
+                    migration_name: migration.name().to_owned(),
+                });
+            };
+
+            for operation in migration.operations() {
+                if let OperationInner::CreateModel { table_name, .. } = operation.inner {
+                    let app_and_model = MigrationLookup::ByAppAndModel {
+                        app: migration.app_name(),
+                        model: table_name.0,
+                    };
+                    if map.insert(app_and_model, index).is_some() {
+                        return Err(MigrationSorterError::DuplicateModel {
+                            app_name: migration.app_name().to_owned(),
+                            model_name: table_name.0.to_owned(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(map)
+    }
+}
+
+fn apply_permutation<T>(migrations: &mut [T], order: &mut [usize]) {
+    for i in 0..order.len() {
+        let mut current = i;
+        let mut next = order[current];
+
+        while next != i {
+            // process the cycle
+            migrations.swap(current, next);
+            order[current] = current;
+
+            current = next;
+            next = order[current];
+        }
+
+        order[current] = current;
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum MigrationLookup<'a> {
+    ByAppAndName { app: &'a str, name: &'a str },
+    ByAppAndModel { app: &'a str, model: &'a str },
+}
+
+impl From<&MigrationDependency> for MigrationLookup<'_> {
+    fn from(dependency: &MigrationDependency) -> Self {
+        match dependency.inner {
+            MigrationDependencyInner::Migration { app, migration } => {
+                MigrationLookup::ByAppAndName {
+                    app,
+                    name: migration,
+                }
+            }
+            MigrationDependencyInner::Model { app, model_name } => MigrationLookup::ByAppAndModel {
+                app,
+                model: model_name,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Graph {
+    vertex_edges: Vec<Vec<usize>>,
+}
+
+impl Graph {
+    #[must_use]
+    fn new(vertex_num: usize) -> Self {
+        Self {
+            vertex_edges: vec![Vec::new(); vertex_num],
+        }
+    }
+
+    fn add_edge(&mut self, from: usize, to: usize) {
+        self.vertex_edges[from].push(to);
+    }
+
+    #[must_use]
+    fn vertex_num(&self) -> usize {
+        self.vertex_edges.len()
+    }
+
+    fn toposort(&mut self) -> Result<Vec<usize>> {
+        let mut visited = vec![VisitedStatus::NotVisited; self.vertex_num()];
+        let mut sorted_indices_stack = Vec::with_capacity(self.vertex_num());
+
+        for index in 0..self.vertex_num() {
+            self.visit(index, &mut visited, &mut sorted_indices_stack)?;
+        }
+
+        assert_eq!(sorted_indices_stack.len(), self.vertex_num());
+
+        sorted_indices_stack.reverse();
+        Ok(sorted_indices_stack)
+    }
+
+    fn visit(
+        &self,
+        index: usize,
+        visited: &mut Vec<VisitedStatus>,
+        sorted_indices_stack: &mut Vec<usize>,
+    ) -> Result<()> {
+        match visited[index] {
+            VisitedStatus::Visited => return Ok(()),
+            VisitedStatus::Visiting => {
+                return Err(MigrationSorterError::CycleDetected);
+            }
+            VisitedStatus::NotVisited => {}
+        }
+
+        visited[index] = VisitedStatus::Visiting;
+
+        for &neighbor in &self.vertex_edges[index] {
+            self.visit(neighbor, visited, sorted_indices_stack)?;
+        }
+
+        visited[index] = VisitedStatus::Visited;
+        sorted_indices_stack.push(index);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+enum VisitedStatus {
+    NotVisited,
+    Visiting,
+    Visited,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migrations::{MigrationDependency, Operation};
+    use crate::db::Identifier;
+    use crate::test::TestMigration;
+
+    #[test]
+    fn graph_toposort() {
+        let mut graph = Graph::new(8);
+        graph.add_edge(0, 3);
+        graph.add_edge(1, 3);
+        graph.add_edge(1, 4);
+        graph.add_edge(2, 4);
+        graph.add_edge(2, 7);
+        graph.add_edge(3, 5);
+        graph.add_edge(3, 6);
+        graph.add_edge(3, 7);
+        graph.add_edge(4, 6);
+
+        let sorted_indices = graph.toposort().unwrap();
+
+        assert_eq!(sorted_indices, vec![2, 1, 4, 0, 3, 7, 6, 5]);
+    }
+
+    #[test]
+    fn create_lookup_table() {
+        let migrations = vec![
+            TestMigration::new(
+                "app1",
+                "migration1",
+                [],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model1"))
+                    .fields(&[])
+                    .build()],
+            ),
+            TestMigration::new(
+                "app1",
+                "migration2",
+                [],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model2"))
+                    .fields(&[])
+                    .build()],
+            ),
+        ];
+
+        let lookup = MigrationSorter::create_lookup_table(&migrations).unwrap();
+
+        assert_eq!(lookup.len(), 4);
+        assert!(lookup.contains_key(&MigrationLookup::ByAppAndName {
+            app: "app1",
+            name: "migration1"
+        }));
+        assert!(lookup.contains_key(&MigrationLookup::ByAppAndName {
+            app: "app1",
+            name: "migration2"
+        }));
+        assert!(lookup.contains_key(&MigrationLookup::ByAppAndModel {
+            app: "app1",
+            model: "model1"
+        }));
+        assert!(lookup.contains_key(&MigrationLookup::ByAppAndModel {
+            app: "app1",
+            model: "model2"
+        }));
+    }
+
+    #[test]
+    fn sort() {
+        let mut migrations = vec![
+            TestMigration::new("app1", "migration2", [], []),
+            TestMigration::new("app1", "migration1", [], []),
+        ];
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        sorter.sort().unwrap();
+
+        assert_eq!(sorter.migrations[0].name(), "migration1");
+        assert_eq!(sorter.migrations[1].name(), "migration2");
+    }
+
+    #[test]
+    fn toposort() {
+        let mut migrations = vec![
+            TestMigration::new("app2", "migration_before", [], []),
+            TestMigration::new(
+                "app2",
+                "migration_after",
+                [MigrationDependency::migration("app2", "migration_before")],
+                [],
+            ),
+            TestMigration::new(
+                "app1",
+                "migration_before",
+                [MigrationDependency::migration("app2", "migration_before")],
+                [],
+            ),
+            TestMigration::new(
+                "app1",
+                "migration_after",
+                [
+                    MigrationDependency::migration("app1", "migration_before"),
+                    MigrationDependency::migration("app2", "migration_after"),
+                ],
+                [],
+            ),
+        ];
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        sorter.sort().unwrap();
+
+        assert_eq!(
+            (migrations[0].app_name(), migrations[0].name()),
+            ("app2", "migration_before")
+        );
+        assert_eq!(
+            (migrations[1].app_name(), migrations[1].name()),
+            ("app1", "migration_before")
+        );
+        assert_eq!(
+            (migrations[2].app_name(), migrations[2].name()),
+            ("app2", "migration_after")
+        );
+        assert_eq!(
+            (migrations[3].app_name(), migrations[3].name()),
+            ("app1", "migration_after")
+        );
+    }
+
+    // migration names must be &'static str
+    const MIGRATION_NAMES: [&str; 100] = [
+        "m0", "m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10", "m11", "m12", "m13",
+        "m14", "m15", "m16", "m17", "m18", "m19", "m20", "m21", "m22", "m23", "m24", "m25", "m26",
+        "m27", "m28", "m29", "m30", "m31", "m32", "m33", "m34", "m35", "m36", "m37", "m38", "m39",
+        "m40", "m41", "m42", "m43", "m44", "m45", "m46", "m47", "m48", "m49", "m50", "m51", "m52",
+        "m53", "m54", "m55", "m56", "m57", "m58", "m59", "m60", "m61", "m62", "m63", "m64", "m65",
+        "m66", "m67", "m68", "m69", "m70", "m71", "m72", "m73", "m74", "m75", "m76", "m77", "m78",
+        "m79", "m80", "m81", "m82", "m83", "m84", "m85", "m86", "m87", "m88", "m89", "m90", "m91",
+        "m92", "m93", "m94", "m95", "m96", "m97", "m98", "m99",
+    ];
+
+    #[test]
+    fn toposort_big() {
+        const MIGRATION_NUM: usize = 100;
+
+        let mut migrations = Vec::new();
+        for i in 0..MIGRATION_NUM {
+            let deps = (0..i)
+                .map(|i| MigrationDependency::migration("app1", MIGRATION_NAMES[i]))
+                .collect::<Vec<_>>();
+
+            migrations.push(TestMigration::new("app1", MIGRATION_NAMES[i], deps, []));
+        }
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        sorter.sort().unwrap();
+
+        for (i, migration) in migrations.iter().enumerate() {
+            assert_eq!(migration.name(), MIGRATION_NAMES[i]);
+        }
+    }
+
+    #[test]
+    fn cycle_detection() {
+        let mut migrations = vec![
+            TestMigration::new(
+                "app1",
+                "migration1",
+                [MigrationDependency::migration("app1", "migration2")],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model1"))
+                    .fields(&[])
+                    .build()],
+            ),
+            TestMigration::new(
+                "app1",
+                "migration2",
+                [MigrationDependency::migration("app1", "migration1")],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model2"))
+                    .fields(&[])
+                    .build()],
+            ),
+        ];
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        assert_eq!(
+            sorter.toposort().unwrap_err(),
+            MigrationSorterError::CycleDetected
+        );
+    }
+
+    #[test]
+    fn duplicate_migration() {
+        let mut migrations = vec![
+            TestMigration::new("app1", "migration1", [], []),
+            TestMigration::new("app1", "migration1", [], []),
+        ];
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        assert_eq!(
+            sorter.toposort().unwrap_err(),
+            MigrationSorterError::DuplicateMigration {
+                app_name: "app1".to_owned(),
+                migration_name: "migration1".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_model() {
+        let mut migrations = vec![
+            TestMigration::new(
+                "app1",
+                "migration1",
+                [],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model1"))
+                    .fields(&[])
+                    .build()],
+            ),
+            TestMigration::new(
+                "app1",
+                "migration2",
+                [],
+                [Operation::create_model()
+                    .table_name(Identifier::new("model1"))
+                    .fields(&[])
+                    .build()],
+            ),
+        ];
+
+        let mut sorter = MigrationSorter::new(&mut migrations);
+        assert_eq!(
+            sorter.toposort().unwrap_err(),
+            MigrationSorterError::DuplicateModel {
+                app_name: "app1".to_owned(),
+                model_name: "model1".to_owned()
+            }
+        );
+    }
+}

--- a/flareon/src/lib.rs
+++ b/flareon/src/lib.rs
@@ -603,7 +603,7 @@ pub async fn run_at(project: FlareonProject, listener: tokio::net::TcpListener) 
         for app in &context.apps {
             migrations.extend(app.migrations());
         }
-        let migration_engine = MigrationEngine::new(migrations);
+        let migration_engine = MigrationEngine::new(migrations)?;
         migration_engine.run(database).await?;
     }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,6 @@ format_code_in_doc_comments = true
 group_imports = "StdExternalCrate"
 imports_granularity = "module"
 normalize_comments = true
-reorder_impl_items = true
 unstable_features = true
 use_field_init_shorthand = true
 wrap_comments = true


### PR DESCRIPTION
For now the system only really create dependency on the previous migration in the app. Eventually we'll extend this to handle ForeignKeys and other relationship types as well.