### PR TITLE
chore(cargo-audit): disable RSA advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071", # no fix available as of 2024-12-07: https://github.com/RustCrypto/RSA/issues/19
+]


### PR DESCRIPTION
This disables checking for `RUSTSEC-2023-0071` in our cargo-audit config. This really only generates noise in **all the PRs** for now, as we already have #72 to track this. Until a fix is available, there's no point in spamming all PRs with CI failures because of this.