### PR TITLE
chore(deps): use upstream `fake` again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,8 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 [[package]]
 name = "dummy"
 version = "0.9.1"
-source = "git+https://github.com/m4tx/fake-rs.git#7414661e15da393b0c4a45dcdd81f8e57c70b459"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ee4e39146145f7dd28e6c85ffdce489d93c0d9c88121063b8aacabbd9858d2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -846,8 +847,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "3.0.1"
-source = "git+https://github.com/m4tx/fake-rs.git#7414661e15da393b0c4a45dcdd81f8e57c70b459"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
 dependencies = [
  "chrono",
  "deunicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,7 @@ darling = "0.20"
 derive_builder = "0.20"
 derive_more = "1"
 env_logger = "0.11"
-# TODO: replace with upstream when https://github.com/cksac/fake-rs/pull/204 is merged and released
-fake = { git = "https://github.com/m4tx/fake-rs.git" }
+fake = "3.1"
 flareon = { path = "flareon" }
 flareon_codegen = { path = "flareon-codegen" }
 flareon_macros = { path = "flareon-macros" }


### PR DESCRIPTION
Our contributions were merged and released, so using a patched version from git is no longer necessary.